### PR TITLE
fix(backends/mcp): use correct link to MCP multiplex page

### DIFF
--- a/content/docs/backends/mcp.md
+++ b/content/docs/backends/mcp.md
@@ -14,7 +14,7 @@ An MCP backend allows exposing MCP servers through the agentgateway.
 
 An MCP server exposes external data sources and tools so that LLM applications can access them. Typically, you want to deploy these servers remotely and have authorization mechanisms in place so that LLM applications can safely access the data.
 
-With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing](/docs/setup/examples/multiplex) guide. 
+With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing](/docs/backends/multiplex/) guide.
 
 ## Before you begin
 


### PR DESCRIPTION
- correct the link in "About MCP"

Fixes: #44 