### PR TITLE
Fix CORS configuration for the Streamable HTTP MCP example

### DIFF
--- a/content/docs/mcp/connect/http.md
+++ b/content/docs/mcp/connect/http.md
@@ -32,6 +32,8 @@ Connect to an MCP server via streamable HTTP.
                - "*"
              allowHeaders:
                - "*"
+             exposeHeaders:
+               - "Mcp-Session-Id"
          backends:
          - mcp:
              targets:


### PR DESCRIPTION
The current docs only mention allowOrigins and allowHeaders for CORS. However, in browser environments, exposeHeaders is also required; otherwise the browser can’t read the session ID from the response headers.

I ran into this issue while using MCP Inspector in direct mode.
<img width="618" height="1162" alt="image" src="https://github.com/user-attachments/assets/6ca8958d-7724-4916-96ca-5305070dacfb" />
