### PR TITLE
Add simplified redirects to website

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,9 @@
+# Cloudflare Pages Redirects for agentgateway.dev
+# This allows simplified URLs like agentgateway.dev/examples/basic/config.yaml
+# instead of the full GitHub raw URL
+
+# Installation script shortcut
+/install https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/common/scripts/get-agentgateway
+
+# Redirect all paths under /examples to GitHub raw content
+/examples/* https://raw.githubusercontent.com/agentgateway/agentgateway/main/examples/:splat


### PR DESCRIPTION
`curl -sL https://agentgateway.dev/install | bash`

vs

`curl https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/common/scripts/get-agentgateway | bash`

I didn't update the docs using the old links so we can verify it actualyl works first

(cherry picked from commit 27f24498fa839569d79adfa33fe6772339045bb9)