### PR TITLE
Fix dark mode sidebar nav

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -10,3 +10,16 @@
 .content, .sidebar-container, .hextra-toc, .hx-text-base {
   font-family: 'Open Sans', 'ui-sans-serif', 'system-ui', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'
 }
+
+/* Dark mode sidebar: strong contrast on hover and active so white text is readable */
+.dark .sidebar-container nav a.sidebar-active-item,
+.dark .sidebar-container a.sidebar-active-item {
+  background-color: rgb(17, 24, 39) !important; /* gray-900 */
+  color: rgb(255, 255, 255) !important;
+}
+
+.dark .sidebar-container nav a:hover:not(.sidebar-active-item),
+.dark .sidebar-container a:hover:not(.sidebar-active-item) {
+  background-color: rgb(17, 24, 39) !important; /* gray-900 */
+  color: rgb(255, 255, 255) !important;
+}


### PR DESCRIPTION
Currently, the sidebar nav in dark mode has a light hover-over that does not contrast well.

<img width="464" height="402" alt="image" src="https://github.com/user-attachments/assets/90360dc4-dbb5-4d6a-a107-9609d1a9d18c" />


This updates it to match the righthand TOC hover-over colors (dark hover-over so the text contrast is fine.)

local preview:

<img width="778" height="439" alt="image" src="https://github.com/user-attachments/assets/1dc8abdd-d146-4e3b-ab90-da435060ca47" />
