### PR TITLE
Fix indentation in static-mcp md

### DIFF
--- a/assets/agw-docs/pages/agentgateway/mcp/static.md
+++ b/assets/agw-docs/pages/agentgateway/mcp/static.md
@@ -83,14 +83,13 @@ metadata:
   name: mcp
 spec:
   parentRefs:
-  - name: agentgateway-proxy
-    namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}  
+    - name: agentgateway-proxy
+      namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}  
   rules:
-  - 
-    backendRefs:
-    - name: mcp-backend
-      group: agentgateway.dev
-      kind: {{< reuse "agw-docs/snippets/backend.md" >}}  
+    - backendRefs:
+      - name: mcp-backend
+        group: agentgateway.dev
+        kind: {{< reuse "agw-docs/snippets/backend.md" >}}  
 EOF
 ```
 


### PR DESCRIPTION
I found a indentation issue in static-mcp.md see https://kgateway.dev/docs/agentgateway/main/mcp/static-mcp/

```
kubectl apply -f- <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: mcp
spec:
  parentRefs:
  - name: agentgateway-proxy
    namespace: agentgateway-system  
  rules:
  - 
    backendRefs:
    - name: mcp-backend
      group: agentgateway.dev
      kind: AgentgatewayBackend  
EOF
```

