### PR TITLE
Fix provider routing documentation

### DIFF
--- a/assets/agw-docs/pages/agentgateway/llm/providers/vertex.md
+++ b/assets/agw-docs/pages/agentgateway/llm/providers/vertex.md
@@ -54,7 +54,7 @@ Set up an [agentgateway proxy]({{< link-hextra path="/setup" >}}).
            name: vertex-ai-secret
    EOF
    ```
-5. Create an HTTPRoute resource that routes incoming traffic to the {{< reuse "agw-docs/snippets/backend.md" >}}. The following example sets up a route on the `/openai` path to the {{< reuse "agw-docs/snippets/backend.md" >}} that you previously created. The `URLRewrite` filter rewrites the path from `/openai` to the path of the API in the LLM provider that you want to use, `/v1/chat/completions`.
+5. Create an HTTPRoute resource that routes incoming traffic to the {{< reuse "docs/snippets/backend.md" >}}. The following example sets up a route on the `/vertex` path. Note that {{< reuse "docs/snippets/kgateway.md" >}} automatically rewrites the endpoint to the appropriate chat completion endpoint of the LLM provider for you, based on the LLM provider that you set up in the {{< reuse "docs/snippets/backend.md" >}} resource.
 
    ```yaml
    kubectl apply -f- <<EOF

--- a/assets/docs/snippets/gemini-setup.md
+++ b/assets/docs/snippets/gemini-setup.md
@@ -47,7 +47,7 @@
    | `gemini.model`     | The model to use to generate responses. In this example, you use the `gemini-2.5-flash-lite` model. For more models, see the [Google AI docs](https://ai.google.dev/gemini-api/docs/models).                                             |
    | `policies.auth` | The authentication token to use to authenticate to the LLM provider. The example refers to the secret that you created in the previous step.   |
 
-4. Create an HTTPRoute resource that routes incoming traffic to the {{< reuse "agw-docs/snippets/backend.md" >}}. The following example sets up a route on the `/openai` path to the {{< reuse "agw-docs/snippets/backend.md" >}} that you previously created. The `URLRewrite` filter rewrites the path from `/openai` to the path of the API in the LLM provider that you want to use, `/v1/chat/completions`.
+4. Create an HTTPRoute resource that routes incoming traffic to the {{< reuse "docs/snippets/backend.md" >}}. The following example sets up a route on the `/gemini` path to the {{< reuse "docs/snippets/backend.md" >}} that you previously created. Note that {{< reuse "/docs/snippets/kgateway.md" >}} automatically rewrites the endpoint that you set up (such as `/gemini`) to the appropriate chat completion endpoint of the LLM provider for you, based on the LLM provider that you set up in the {{< reuse "docs/snippets/backend.md" >}} resource.
 
    ```yaml
    kubectl apply -f- <<EOF


### PR DESCRIPTION
Remove OpenAI-specific paths from generic HTTPRoute documentation and clarify provider-agnostic routing with automatic endpoint rewriting.

<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

This PR fixes incorrect OpenAI-specific routing references in a generic HTTPRoute example.

It removes hardcoded `/openai` and `/v1/chat/completions` paths and updates the documentation to reflect kgateway’s provider-agnostic routing behavior.

Fixes: https://github.com/kgateway-dev/kgateway.dev/issues/605


# Change Type

/kind documentation


# Changelog

```release-note
NONE


# Additional Notes

This is a documentation-only change and does not affect runtime behavior.



