### PR TITLE
resize chatbot in desktop

### DIFF
--- a/layouts/partials/chatbot.html
+++ b/layouts/partials/chatbot.html
@@ -8,14 +8,14 @@
 
 <!-- Chat Bot Widget for Docs Pages -->
 <div id="chatbot-widget" x-data="chatbot" @keydown.escape.window="close()">
-  <!-- Trigger Button -->
+  <!-- Trigger Button: prominent on desktop (TOC width), compact on mobile -->
   <button
     @click="toggle()"
-    class="chatbot-trigger fixed bottom-6 right-6 z-[9998] flex items-center gap-2 px-5 py-3 bg-gradient-to-br from-violet-600 to-violet-700 text-white border-none rounded-full font-inherit text-sm font-medium cursor-pointer transition-all duration-200 sm:bottom-4 sm:right-4 sm:px-4 sm:py-2.5 sm:text-[13px]"
-    :class="isOpen ? 'shadow-[0_2px_8px_rgba(124,58,237,0.3)] opacity-80 hover:opacity-100' : 'shadow-[0_4px_14px_rgba(124,58,237,0.4)] hover:-translate-y-0.5 hover:shadow-[0_6px_20px_rgba(124,58,237,0.5)] active:translate-y-0'"
+    class="chatbot-trigger fixed bottom-4 right-4 z-[9998] flex items-center justify-center gap-2 min-w-0 px-4 py-2.5 text-[13px] bg-gradient-to-br from-violet-600 to-violet-700 text-white border-none rounded-full font-inherit font-medium cursor-pointer transition-all duration-200 shadow-[0_4px_14px_rgba(124,58,237,0.4)] sm:min-w-64 sm:gap-3 sm:px-6 sm:py-3.5 sm:text-base sm:shadow-[0_4px_18px_rgba(124,58,237,0.45)] sm:bottom-6 sm:right-6"
+    :class="isOpen ? 'shadow-[0_2px_8px_rgba(124,58,237,0.3)] opacity-80 hover:opacity-100' : 'hover:-translate-y-0.5 hover:shadow-[0_6px_22px_rgba(124,58,237,0.55)] active:translate-y-0'"
     aria-label="Ask AI"
   >
-    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="shrink-0 w-5 h-5 sm:w-[22px] sm:h-[22px]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
     </svg>
     <span>Ask AI</span>


### PR DESCRIPTION
We got some feedback that the Ask AI button could be more prominent.

### Before
<img width="3228" height="1768" alt="image" src="https://github.com/user-attachments/assets/c2da02b2-53da-49b5-a11b-07196d6edf1a" />


### After
<img width="2892" height="1758" alt="image" src="https://github.com/user-attachments/assets/0a87c8ff-1f59-4389-8e5d-328df2f28bb3" />
