### PR TITLE
fix broken MCP multiplexing documentation links

### DIFF
--- a/assets/agw-docs/pages/agentgateway/mcp/about.md
+++ b/assets/agw-docs/pages/agentgateway/mcp/about.md
@@ -6,7 +6,7 @@ Learn more about MCP and common challenges when adopting MCP in enterprise envir
 
 An MCP server exposes external data sources and tools so that LLM applications can access them. Typically, you want to deploy these servers remotely and have authorization mechanisms in place so that LLM applications can safely access the data.
 
-With {{< reuse "agw-docs/snippets/agentgateway.md" >}}, you can connect to one or multiple MCP servers in any environment. {{< reuse "agw-docs/snippets/agentgateway-capital.md" >}} proxies requests to the MCP tool that is exposed on the server. <!-- You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing]({{< link-hextra path="/mcp/connect/multiplex/">}}) guide. -->
+With {{< reuse "agw-docs/snippets/agentgateway.md" >}}, you can connect to one or multiple MCP servers in any environment. {{< reuse "agw-docs/snippets/agentgateway-capital.md" >}} proxies requests to the MCP tool that is exposed on the server. <!-- You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing]({{< link-hextra path="/tutorials/multiplex/">}}) guide. -->
 
 ## MCP vs. A2A
 

--- a/content/docs/standalone/latest/mcp/about.md
+++ b/content/docs/standalone/latest/mcp/about.md
@@ -13,7 +13,7 @@ Learn more about MCP and common challenges when adopting MCP in enterprise envir
 
 An MCP server exposes external data sources and tools so that LLM applications can access them. Typically, you want to deploy these servers remotely and have authorization mechanisms in place so that LLM applications can safely access the data.
 
-With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing]({{< link-hextra path="/mcp/connect/multiplex/" >}}) guide. 
+With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing]({{< link-hextra path="/tutorials/multiplex/" >}}) guide.
 
 ## MCP vs. A2A
 

--- a/content/docs/standalone/latest/mcp/mcp-target-policies.md
+++ b/content/docs/standalone/latest/mcp/mcp-target-policies.md
@@ -44,7 +44,7 @@ Target-level policies override backend-level policies for the same policy type.
 
 ## Before you begin
 
-[Set up MCP multiplexed backends]({{< link-hextra path="/mcp/connect/multiplex/" >}}).
+[Set up MCP multiplexed backends]({{< link-hextra path="/tutorials/multiplex/" >}}).
 
 ## Configuration examples
 

--- a/content/docs/standalone/latest/tutorials/multiplex/_index.md
+++ b/content/docs/standalone/latest/tutorials/multiplex/_index.md
@@ -127,5 +127,5 @@ Agentgateway federates multiple MCP servers:
 {{< cards >}}
   {{< card link="/docs/tutorials/openapi" title="OpenAPI to MCP" subtitle="Expose REST APIs as tools" >}}
   {{< card link="/docs/tutorials/authorization" title="Authorization" subtitle="Add JWT authentication" >}}
-  {{< card link="/docs/mcp/connect/multiplex" title="Multiplexing Guide" subtitle="Advanced options" >}}
+  {{< card link="/docs/tutorials/multiplex" title="Multiplexing Guide" subtitle="Advanced options" >}}
 {{< /cards >}}

--- a/content/docs/standalone/main/mcp/about.md
+++ b/content/docs/standalone/main/mcp/about.md
@@ -13,7 +13,7 @@ Learn more about MCP and common challenges when adopting MCP in enterprise envir
 
 An MCP server exposes external data sources and tools so that LLM applications can access them. Typically, you want to deploy these servers remotely and have authorization mechanisms in place so that LLM applications can safely access the data.
 
-With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing]({{< link-hextra path="/mcp/connect/multiplex/" >}}) guide. 
+With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [MCP multiplexing]({{< link-hextra path="/tutorials/multiplex/" >}}) guide. 
 
 ## MCP vs. A2A
 

--- a/content/docs/standalone/main/mcp/mcp-target-policies.md
+++ b/content/docs/standalone/main/mcp/mcp-target-policies.md
@@ -44,7 +44,7 @@ Target-level policies override backend-level policies for the same policy type.
 
 ## Before you begin
 
-[Set up MCP multiplexed backends]({{< link-hextra path="/mcp/connect/multiplex/" >}}).
+[Set up MCP multiplexed backends]({{< link-hextra path="/tutorials/multiplex/" >}}).
 
 ## Configuration examples
 

--- a/content/docs/standalone/main/tutorials/multiplex/_index.md
+++ b/content/docs/standalone/main/tutorials/multiplex/_index.md
@@ -127,5 +127,5 @@ Agentgateway federates multiple MCP servers:
 {{< cards >}}
   {{< card link="/docs/tutorials/openapi" title="OpenAPI to MCP" subtitle="Expose REST APIs as tools" >}}
   {{< card link="/docs/tutorials/authorization" title="Authorization" subtitle="Add JWT authentication" >}}
-  {{< card link="/docs/mcp/connect/multiplex" title="Multiplexing Guide" subtitle="Advanced options" >}}
+  {{< card link="/docs/tutorials/multiplex" title="Multiplexing Guide" subtitle="Advanced options" >}}
 {{< /cards >}}


### PR DESCRIPTION
I realized that the links to "MCP multiplexing" guide were pointing to `/mcp/connect/multiplex/`, which returns 404. Updated them to point to the correct location at `/tutorials/multiplex/`.

For example, https://agentgateway.dev/docs/standalone/latest/tutorials/multiplex/, this page points to 404 for mcp multiplexing links.