### PR TITLE
Added --server-side to experimental-install.yaml

### DIFF
--- a/assets/agw-docs/pages/agentgateway/mcp/mcp-auth-setup.md
+++ b/assets/agw-docs/pages/agentgateway/mcp/mcp-auth-setup.md
@@ -15,7 +15,7 @@ For more information, see the [JWT auth docs]({{< link-hextra path="/mcp/mcp-acc
 3. Follow the steps to [set up Keycloak]({{< link-hextra path="/mcp/auth/keycloak/" >}}).
 4. Install the experimental channel Gateway API.
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
 ## Configure MCP auth

--- a/assets/agw-docs/pages/operations/upgrade.md
+++ b/assets/agw-docs/pages/operations/upgrade.md
@@ -82,7 +82,7 @@ During the upgrade, pods that run the new version of the control plane and proxi
    * Experimental channel: Note that some CRDs are prefixed with `X` to indicate that the entire CRD is experimental and subject to change.
      
      ```sh
-     kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+     kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
      ```   
 
    Example output: 

--- a/assets/agw-docs/pages/setup/listener-mtls.md
+++ b/assets/agw-docs/pages/setup/listener-mtls.md
@@ -29,7 +29,7 @@ Self-signed certificates are used for demonstration purposes. Do not use self-si
 
 5. Install the experimental channel of the Kubernetes Gateway API. This API is required to use the FrontendTLS configuration on a Gateway.   
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
 

--- a/assets/agw-docs/pages/setup/listeners/listener-mtls.md
+++ b/assets/agw-docs/pages/setup/listeners/listener-mtls.md
@@ -43,7 +43,7 @@ Self-signed certificates are used for demonstration purposes. Do not use self-si
 
 3. Install the experimental channel of the Kubernetes Gateway API. This API is required to use the FrontendTLS configuration on a Gateway.   
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
 4. Ensure that you installed {{< reuse "agw-docs/snippets/kgateway.md" >}} with the `--set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true` Helm flag to use experimental Kubernetes Gateway API features. For an example, see the [Get started guide]({{< link-hextra path="/quickstart" >}}).

--- a/assets/agw-docs/pages/setup/listeners/tcp.md
+++ b/assets/agw-docs/pages/setup/listeners/tcp.md
@@ -8,7 +8,7 @@ The following guide deploys a sample TCP echo app, sets up a TCP listener on the
 
 1. Install the experimental channel of the {{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} so that you can use TCPRoutes.
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
 2. Ensure that you installed {{< reuse "agw-docs/snippets/kgateway.md" >}} with the `--set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true` Helm flag to use experimental Kubernetes Gateway API features. For an example, see the [Get started guide]({{< link-hextra path="/quickstart" >}}).

--- a/assets/agw-docs/snippets/agentgateway/get-started.md
+++ b/assets/agw-docs/snippets/agentgateway/get-started.md
@@ -9,7 +9,7 @@
    {{% tab tabName="Experimental" %}}
    CRDs in the experimental channel are required to use some experimental features in the Gateway API. Guides that require experimental CRDs note this requirement in their prerequisites.
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```  
    {{% /tab %}}
    {{< /tabs >}}

--- a/assets/agw-docs/snippets/agentgateway/helm.md
+++ b/assets/agw-docs/snippets/agentgateway/helm.md
@@ -8,7 +8,7 @@
    {{% tab tabName="Experimental" %}}
    CRDs in the experimental channel are required to use some experimental features in the Gateway API. Guides that require experimental CRDs note this requirement in their prerequisites.
    ```sh {paths="experimental"}
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
    {{% /tab %}}
    {{< /tabs >}}

--- a/assets/agw-docs/snippets/get-started.md
+++ b/assets/agw-docs/snippets/get-started.md
@@ -9,7 +9,7 @@
    {{% tab tabName="Experimental" %}}
    CRDs in the experimental channel are required to use some experimental features in the Gateway API. Guides that require experimental CRDs note this requirement in their prerequisites.
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```  
    {{% /tab %}}
    {{< /tabs >}}

--- a/assets/agw-docs/snippets/k8sgwapi-exp.md
+++ b/assets/agw-docs/snippets/k8sgwapi-exp.md
@@ -25,5 +25,5 @@ controller:
 **Sample command for version {{< reuse "agw-docs/versions/k8s-gw-version.md" >}}**: Note that some CRDs are prefixed with `X` to indicate that the entire CRD is experimental and subject to change.
     
 ```sh
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
 ```

--- a/assets/agw-docs/snippets/prereq-1-3-channel-experimental.md
+++ b/assets/agw-docs/snippets/prereq-1-3-channel-experimental.md
@@ -19,7 +19,7 @@
 
 4. **Important**: Install the experimental channel of version 1.3 of the Kubernetes Gateway API to use this feature.
    ```shell
-   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/experimental-install.yaml
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/experimental-install.yaml --server-side
    ```
 
 5. **Important**: To use experimental Gateway API features in kgateway, you must enable the `KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES` environment variable in your kgateway controller deployment. This setting defaults to `false` and must be explicitly enabled. For example, if you installed kgateway via Helm, add the following to your Helm values and upgrade your installation.

--- a/assets/agw-docs/snippets/prereq-listeners.md
+++ b/assets/agw-docs/snippets/prereq-listeners.md
@@ -6,5 +6,5 @@
 
    **ListenerSets**: To use ListenerSets, you must install the experimental channel of the Kubernetes Gateway API. 
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```

--- a/content/docs/kubernetes/latest/setup/listeners/http.md
+++ b/content/docs/kubernetes/latest/setup/listeners/http.md
@@ -13,7 +13,7 @@ Create an HTTP listener on your gateway proxy. Your proxy listens for HTTP traff
 
    **ListenerSets**: To use ListenerSets, you must install the experimental channel of the Kubernetes Gateway API. 
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
    You must also ensure that you installed {{< reuse "agw-docs/snippets/kgateway.md" >}} with the `--set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true` Helm flag to use experimental Kubernetes Gateway API features. For an example, see the [Get started guide]({{< link-hextra path="/quickstart" >}}).

--- a/content/docs/kubernetes/latest/setup/listeners/https.md
+++ b/content/docs/kubernetes/latest/setup/listeners/https.md
@@ -27,7 +27,7 @@ Create an HTTPS listener on your agentgateway proxy so that your proxy listens f
 
    **ListenerSets**: To use ListenerSets, you must install the experimental channel of the Kubernetes Gateway API. 
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
    You must also ensure that you installed {{< reuse "agw-docs/snippets/kgateway.md" >}} with the `--set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true` Helm flag to use experimental Kubernetes Gateway API features. For an example, see the [Get started guide]({{< link-hextra path="/quickstart" >}}).

--- a/content/docs/kubernetes/latest/setup/listeners/tcp.md
+++ b/content/docs/kubernetes/latest/setup/listeners/tcp.md
@@ -13,7 +13,7 @@ The following guide deploys a sample TCP echo app, sets up a TCP listener on the
 
 1. Install the experimental channel of the {{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} so that you can use TCPRoutes.
    ```sh
-   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml
+   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml --server-side
    ```
 
 2. Ensure that you installed {{< reuse "agw-docs/snippets/kgateway.md" >}} with the `--set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true` Helm flag to use experimental Kubernetes Gateway API features. For an example, see the [Get started guide]({{< link-hextra path="/quickstart" >}}).


### PR DESCRIPTION
Added --server-side to `kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{< reuse "docs/versions/k8s-gw-version.md" >}}/experimental-install.yaml ` commands.