### PR TITLE
Fix codeblock formatting

### DIFF
--- a/content/docs/standalone/latest/llm/api-keys.md
+++ b/content/docs/standalone/latest/llm/api-keys.md
@@ -92,7 +92,7 @@ You can store your API key in a file and load the file into agentgateway during 
    ```yaml
    cat <<EOF > config.yaml
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
+   binds:
    - port: 3000
      listeners:
      - routes:


### PR DESCRIPTION
Incorrect indentation broke the rendering of the codeblock

<img width="600" src="https://github.com/user-attachments/assets/e51a341c-8992-4d6f-907f-9a54e1073e58" />
