### PR TITLE
fix mobile view

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -14,10 +14,27 @@
   });
 
   function openMobileNav() {
+    closeMobileSidebar();
     document.querySelector('.mobile-nav').classList.toggle('visible');
     document.querySelector('.hamburger').classList.toggle('visible');
     document.querySelector('.x').classList.toggle('visible');
     document.querySelector('body').style.overflow = document.querySelector('body').style.overflow === 'hidden' ? 'scroll' : 'hidden';
+  }
+
+  function toggleMobileSidebar() {
+    var sidebar = document.querySelector('.sidebar-mobile-panel');
+    var overlay = document.querySelector('.sidebar-mobile-overlay');
+    if (sidebar && overlay) {
+      sidebar.classList.toggle('mobile-sidebar-open');
+      overlay.classList.toggle('active');
+    }
+  }
+
+  function closeMobileSidebar() {
+    var sidebar = document.querySelector('.sidebar-mobile-panel');
+    var overlay = document.querySelector('.sidebar-mobile-overlay');
+    if (sidebar) sidebar.classList.remove('mobile-sidebar-open');
+    if (overlay) overlay.classList.remove('active');
   }
 </script>
 
@@ -414,8 +431,10 @@
 
   <div class="mobile-nav-overflow-wrapper block lg:hidden">
   <div class="mobile-nav bg-primary-bg w-screen z-40">
-    <div class="h-full flex flex-col px-4 items-stretch justify-end w-screen">
+    <div class="h-full flex flex-col px-4 items-stretch pt-24 pb-8 overflow-y-auto w-screen">
       <a class="whitespace-nowrap text-[1.5625rem] text-primary-text py-5" href="/docs/">Docs</a>
+      <a class="whitespace-nowrap text-[1.25rem] text-secondary-text py-3 pl-6" href="/docs/standalone/latest/">Standalone</a>
+      <a class="whitespace-nowrap text-[1.25rem] text-secondary-text py-3 pl-6" href="/docs/kubernetes/latest/">Kubernetes</a>
       <a class="whitespace-nowrap text-[1.5625rem] text-primary-text py-5" href="/tutorials/">Tutorials</a>
       <a class="whitespace-nowrap text-[1.25rem] text-secondary-text py-3 pl-6" href="/docs/standalone/latest/tutorials">Standalone</a>
       <a class="whitespace-nowrap text-[1.25rem] text-secondary-text py-3 pl-6" href="/docs/kubernetes/latest/tutorials">Kubernetes</a>
@@ -562,13 +581,22 @@
   </nav>
 
   <nav class="mobile-nav-bar fixed top-0 left-0 right-0 border-b border-gray-200 dark:border-white/10 w-full block lg:hidden z-[100] bg-white dark:bg-gray-900{{ if $isBlogPage }} navbar-dark-bg{{ end }}">
-    <div class="py-3 pr-4 flex justify-between items-center">
-      {{- $page := . -}}
-      {{- $mobileLogoParams := dict "Page" $page "attributes" "height=\"50\"" -}}
-      {{- if $isBlogPage -}}
-        {{- $mobileLogoParams = merge $mobileLogoParams (dict "forceDark" true) -}}
-      {{- end -}}
-      <a href="/">{{ partial "utils/logo.html" $mobileLogoParams }}</a>
+    <div class="py-3 px-4 flex justify-between items-center">
+      <div class="flex items-center gap-1">
+        {{- if $isDocsPage -}}
+        <button onclick="toggleMobileSidebar()" class="p-2 -ml-2 text-gray-700 dark:text-gray-300" aria-label="Toggle docs navigation">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h10M4 18h16"/>
+          </svg>
+        </button>
+        {{- end -}}
+        {{- $page := . -}}
+        {{- $mobileLogoParams := dict "Page" $page "attributes" "height=\"50\"" -}}
+        {{- if $isBlogPage -}}
+          {{- $mobileLogoParams = merge $mobileLogoParams (dict "forceDark" true) -}}
+        {{- end -}}
+        <a href="/">{{ partial "utils/logo.html" $mobileLogoParams }}</a>
+      </div>
       <button class="p-4 bg-primary-text rounded-lg flex items-center" onClick="openMobileNav()">
         <div class="visible hamburger hidden">
           {{ partial "utils/icon.html" (dict "name" "hamburger" ) }}
@@ -582,7 +610,7 @@
 
   <div class="mobile-nav-overflow-wrapper block lg:hidden">
   <div class="mobile-nav bg-primary-bg w-screen z-40">
-    <div class="h-full flex flex-col px-4 items-stretch justify-end w-screen">
+    <div class="h-full flex flex-col px-4 items-stretch pt-20 pb-8 overflow-y-auto w-screen">
       <a class="whitespace-nowrap text-[1.5625rem] text-primary-text py-5" href="/docs/">Docs</a>
       <a class="whitespace-nowrap text-[1.25rem] text-secondary-text py-3 pl-6" href="/docs/standalone/latest/">Standalone</a>
       <a class="whitespace-nowrap text-[1.25rem] text-secondary-text py-3 pl-6" href="/docs/kubernetes/latest/">Kubernetes</a>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -16,7 +16,7 @@
   {{- $currentVersion := "" -}}
   {{- $section := "" -}}
   {{- $isVersionedDocs := false -}}
-  
+
   {{- /* Check if we're in a versioned docs section */ -}}
   {{- if and (ge (len $segments) 4) (eq (index $segments 1) "docs") -}}
     {{- $section = index $segments 2 -}}
@@ -27,15 +27,103 @@
     {{- end -}}
   {{- end -}}
 
+  <style>
+    /* Mobile sidebar: slide-in panel below xl breakpoint */
+    @media (max-width: 1279.99px) {
+      .sidebar-mobile-panel {
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        bottom: 0 !important;
+        width: 280px !important;
+        z-index: 90 !important;
+        transform: translateX(-100%);
+        transition: transform 300ms ease-in-out;
+        background: white;
+        padding-top: 64px;
+        visibility: hidden;
+        overflow-y: auto;
+        display: flex !important;
+        flex-direction: column !important;
+      }
+      .dark .sidebar-mobile-panel {
+        background: rgb(17, 24, 39);
+      }
+      .sidebar-mobile-panel.mobile-sidebar-open {
+        transform: translateX(0);
+        visibility: visible;
+      }
+    }
+    .sidebar-mobile-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 89;
+    }
+    .sidebar-mobile-overlay.active {
+      display: block;
+    }
+    /* Hide mobile-only header on desktop */
+    @media (min-width: 1280px) {
+      .sidebar-mobile-only {
+        display: none !important;
+      }
+    }
+  </style>
+
+  <!-- Mobile sidebar overlay -->
+  <div class="sidebar-mobile-overlay" onclick="closeMobileSidebar()"></div>
+
   {{- if $isVersionedDocs -}}
     {{- /* Get the docs section page for the current version */ -}}
     {{- $versionPrefix := printf "/docs/%s/%s/" $section $currentVersion -}}
     {{- $docsSectionPath := printf "/docs/%s/%s/" $section $currentVersion -}}
     {{- $docsSection := $context.Site.GetPage $docsSectionPath -}}
-    
+
     {{- if $docsSection -}}
-      {{- /* Render sidebar starting from the versioned docs section */ -}}
-      <aside class="sidebar-container hx-order-first hx-hidden hx-w-64 hx-shrink-0 xl:hx-block print:hx-hidden hx-flex hx-flex-col">
+      {{- /* Render sidebar with mobile slide-in support */ -}}
+      <aside class="sidebar-container sidebar-mobile-panel hx-order-first hx-w-64 hx-shrink-0 hx-hidden xl:hx-block print:hx-hidden hx-flex hx-flex-col">
+
+        {{- /* Mobile-only: Section selector + version picker */ -}}
+        <div class="sidebar-mobile-only" style="border-bottom: 1px solid; border-color: inherit;">
+          {{- /* Section selector: Standalone / Kubernetes */ -}}
+          <div style="display: flex; gap: 0.5rem; padding: 0.75rem;">
+            {{- $otherSection := cond (eq $section "standalone") "kubernetes" "standalone" -}}
+            <a href="/docs/{{ $section }}/{{ $currentVersion }}/"
+               style="flex: 1; text-align: center; padding: 0.5rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; background: rgb(219 234 254); color: rgb(30 64 175);"
+               class="dark:hx-bg-primary-400/10 dark:hx-text-primary-600">
+              {{ $section | title }}
+            </a>
+            <a href="/docs/{{ $otherSection }}/{{ $currentVersion }}/"
+               style="flex: 1; text-align: center; padding: 0.5rem; border-radius: 0.375rem; font-size: 0.875rem; font-weight: 500; color: rgb(75 85 99);"
+               class="hover:hx-bg-gray-100 dark:hx-text-gray-400 dark:hover:hx-bg-gray-800">
+              {{ $otherSection | title }}
+            </a>
+          </div>
+          {{- /* Version picker */ -}}
+          {{- $versions := slice -}}
+          {{- if and $section (isset site.Params.sections $section) -}}
+            {{- $versions = (index site.Params.sections $section).versions -}}
+          {{- end -}}
+          {{- if $versions -}}
+            <div style="padding: 0 0.75rem 0.75rem;">
+              <div style="display: flex; gap: 0.25rem; flex-wrap: wrap;">
+                {{- $filtered := after 4 $segments -}}
+                {{- $newPath := printf "/%s" (delimit $filtered "/") -}}
+                {{- range $versions -}}
+                  {{- $isActive := eq $currentVersion .linkVersion -}}
+                  <a href="/docs/{{ $section }}/{{ .linkVersion }}{{ $newPath }}"
+                     style="padding: 0.375rem 0.75rem; border-radius: 0.375rem; font-size: 0.75rem; font-weight: 500; {{ if $isActive }}background: rgb(229 231 235); color: rgb(17 24 39);{{ else }}color: rgb(107 114 128);{{ end }}"
+                     class="{{ if $isActive }}dark:hx-bg-gray-700 dark:hx-text-white{{ else }}hover:hx-bg-gray-100 dark:hx-text-gray-400 dark:hover:hx-bg-gray-800{{ end }}">
+                    {{ .dropdown }}
+                  </a>
+                {{- end -}}
+              </div>
+            </div>
+          {{- end -}}
+        </div>
+
         <div class="hextra-scrollbar hx-overflow-y-auto hx-overflow-x-hidden hx-p-4 hx-grow md:hx-h-[calc(100vh-var(--navbar-height)-var(--menu-height))]">
           <nav class="hx-flex hx-flex-col hx-gap-2 hx-text-sm hx-text-gray-600 dark:hx-text-gray-400">
             {{- template "render-sidebar-tree" (dict "page" $docsSection "current" $context "versionPrefix" $versionPrefix "depth" 0) -}}
@@ -75,7 +163,7 @@
     {{- if templates.Exists "partials/hextra/sidebar.html" -}}
       {{- partial "hextra/sidebar.html" (dict "context" $context) -}}
     {{- else -}}
-      <aside class="sidebar-container hx-order-first hx-hidden hx-w-64 hx-shrink-0 xl:hx-block print:hx-hidden hx-flex hx-flex-col">
+      <aside class="sidebar-container sidebar-mobile-panel hx-order-first hx-w-64 hx-shrink-0 hx-hidden xl:hx-block print:hx-hidden hx-flex hx-flex-col">
         <div class="hextra-scrollbar hx-overflow-y-auto hx-overflow-x-hidden hx-p-4 hx-grow md:hx-h-[calc(100vh-var(--navbar-height)-var(--menu-height))]">
           <nav class="hx-flex hx-flex-col hx-gap-2 hx-text-sm hx-text-gray-600 dark:hx-text-gray-400">
             {{- template "render-sidebar-tree" (dict "page" $context "current" $context "versionPrefix" "" "depth" 0) -}}
@@ -117,11 +205,11 @@
   {{- $versionPrefix := .versionPrefix -}}
   {{- $depth := .depth | default 0 -}}
   {{- $maxDepth := 4 -}}
-  
+
   {{- if gt $depth $maxDepth -}}
     {{- return -}}
   {{- end -}}
-  
+
   {{- /* Get children pages that match the version prefix (if specified) */ -}}
   {{- /* Hugo's .Pages is already sorted by weight, so we maintain that order */ -}}
   {{- $children := slice -}}
@@ -134,17 +222,17 @@
       {{- $children = $children | append . -}}
     {{- end -}}
   {{- end -}}
-  
+
   {{- /* Hugo's .Pages is already sorted by weight, maintain that order */ -}}
   {{- $sortedChildren := $children -}}
-  
+
   {{- if gt (len $sortedChildren) 0 -}}
     <ul class="{{ if eq $depth 0 }}hx-mt-2{{ else }}hx-ml-4 hx-mt-1{{ end }} hx-space-y-1">
       {{- range $sortedChildren -}}
         {{- $childIsActive := eq .RelPermalink $current.RelPermalink -}}
         {{- $childIsAncestor := $current.IsDescendant . -}}
         {{- $childIsExpanded := or $childIsActive $childIsAncestor -}}
-        
+
         {{- /* Get grandchildren that match version prefix */ -}}
         {{- $grandchildren := slice -}}
         {{- range .Pages -}}
@@ -156,7 +244,7 @@
             {{- $grandchildren = $grandchildren | append . -}}
           {{- end -}}
         {{- end -}}
-        
+
         <li class="hx-relative">
           <a
             href="{{ .RelPermalink }}"
@@ -170,7 +258,7 @@
               </svg>
             {{- end -}}
           </a>
-          
+
           {{- if and (gt (len $grandchildren) 0) $childIsExpanded -}}
             {{- template "render-sidebar-tree" (dict "page" . "current" $current "versionPrefix" $versionPrefix "depth" (add $depth 1)) -}}
           {{- end -}}


### PR DESCRIPTION
couldn't select the docs from the mobile slideout, closes: https://github.com/agentgateway/website/issues/165

### Before

<img width="864" height="1939" alt="image" src="https://github.com/user-attachments/assets/16c407ff-19b1-4d92-98a8-d639f495e868" />

### After

<img width="530" height="760" alt="image" src="https://github.com/user-attachments/assets/5b8c08e0-5b53-48ee-9832-2a4cf19f73e1" />


Sidebar view
<img width="464" height="777" alt="image" src="https://github.com/user-attachments/assets/4225a7a9-15cd-4ac4-afd0-f1d712f00b8a" />


### Changes Made

  sidebar.html — Mobile sidebar slide-in panel

  - Added CSS that makes the sidebar a fixed slide-in panel on mobile (below 1280px/xl). It uses transform: translateX(-100%) to hide off-screen and slides in when .mobile-sidebar-open is toggled.
  - Added a dark overlay (.sidebar-mobile-overlay) that appears behind the sidebar and closes it when tapped.
  - Added a mobile-only header inside the sidebar with:
    - Section selector (Standalone / Kubernetes tabs) — the current section is highlighted, the other links to the equivalent version in the other section
    - Version picker — shows all configured versions with the active one highlighted
  - These mobile elements are hidden on xl+ screens via @media (min-width: 1280px) rule.

  nav.html — Sidebar toggle + mobile nav fixes

  JS additions:
  - toggleMobileSidebar() — toggles the sidebar panel and overlay
  - closeMobileSidebar() — closes the sidebar (called by overlay click)
  - openMobileNav() now calls closeMobileSidebar() first so the two panels don't overlap

  Docs mobile nav bar:
  - Added a sidebar toggle icon (three horizontal lines, middle one shorter) on the left side of the mobile nav bar, before the logo. Only renders on docs pages.

  Landing page + docs mobile slide-out nav:
  - Changed justify-end → pt-24 pb-8 overflow-y-auto so links flow from top with proper padding (no longer pushed to bottom where they can be clipped on short screens)
  - Added Standalone/Kubernetes sub-links under "Docs" in the landing page mobile nav (previously only had "Docs" link without sub-items)