### PR TITLE
Update crd-ref-docs-config.yaml to fix k8s doc links

### DIFF
--- a/scripts/crd-ref-docs-config.yaml
+++ b/scripts/crd-ref-docs-config.yaml
@@ -11,5 +11,5 @@ processor:
     # - they duplicate the main resource with just metadata + items
     - "(AgentgatewayBackend|AgentgatewayParameters|AgentgatewayPolicy)List$"
 
-renderer:
-  kubernetesVersion: "1.31.0"
+render:
+  kubernetesVersion: "1.31"


### PR DESCRIPTION
Updates crd-ref-docs-config.yaml, which is used by the reference-docs workflow, so that generated links out to the Kubernetes docs in the API reference will now be formatted correctly.

Successful test workflow run from this branch: https://github.com/agentgateway/website/actions/runs/24354161313
And resultant PRs in which the links are fixed: https://github.com/agentgateway/website/pull/387 & https://github.com/agentgateway/website/pull/388