### PR TITLE
Add Flux installation guide

### DIFF
--- a/assets/agw-docs/pages/install/flux.md
+++ b/assets/agw-docs/pages/install/flux.md
@@ -1,0 +1,170 @@
+In this installation guide, you install {{< reuse "/agw-docs/snippets/kgateway.md" >}} in a Kubernetes cluster by using [Flux](https://fluxcd.io/). Flux is a CNCF-graduated, GitOps-based continuous delivery tool that reconciles cluster state from a Git repository or OCI registry. This approach uses the `agentgateway` Helm charts that are published as OCI artifacts to `cr.agentgateway.dev`.
+
+## Before you begin
+
+1. Create or use an existing Kubernetes cluster.
+2. Install the following command-line tools.
+   * [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl), the Kubernetes command line tool. Download the `kubectl` version that is within one minor version of the Kubernetes clusters you plan to use.
+3. If you do not already have Flux installed in your cluster, install it by following the [Flux installation guide](https://fluxcd.io/flux/installation/). You can use the `flux` CLI, the [Flux Operator](https://fluxoperator.dev/), or any other supported method.
+
+## Install
+
+Install {{< reuse "/agw-docs/snippets/kgateway.md" >}} by using Flux. The following steps use `kubectl apply` so you can try the procedure quickly, but in a GitOps workflow you would commit the same manifests to the Git or OCI source that Flux reconciles and let the controllers apply them for you.
+
+1. Create a `gateway-api` namespace and install the custom resources of the {{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} version {{< reuse "agw-docs/versions/k8s-gw-version.md" >}} by creating a `GitRepository` source and a `Kustomization` that reconciles the `standard` CRD channel from the upstream repository.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: v1
+   kind: Namespace
+   metadata:
+     name: gateway-api
+   ---
+   apiVersion: source.toolkit.fluxcd.io/v1
+   kind: GitRepository
+   metadata:
+     name: gateway-api
+     namespace: gateway-api
+   spec:
+     interval: 1h
+     url: https://github.com/kubernetes-sigs/gateway-api
+     ref:
+       tag: v{{< reuse "agw-docs/versions/k8s-gw-version.md" >}}
+     sparseCheckout:
+       - config/crd/standard
+   ---
+   apiVersion: kustomize.toolkit.fluxcd.io/v1
+   kind: Kustomization
+   metadata:
+     name: gateway-api
+     namespace: gateway-api
+   spec:
+     interval: 1h
+     prune: true
+     sourceRef:
+       kind: GitRepository
+       name: gateway-api
+     path: ./config/crd/standard
+   EOF
+   ```
+
+   {{< callout type="info" >}}If you need to use an experimental feature such as TCPRoutes, reconcile the experimental channel by setting `sparseCheckout: [config/crd/experimental]` on the `GitRepository` and `path: ./config/crd/experimental` on the `Kustomization`. For more information, see [Experimental features in Gateway API]({{< link-hextra path="/reference/versions/#experimental-features">}}).{{< /callout >}}
+
+2. Create the `{{< reuse "agw-docs/snippets/namespace.md" >}}` namespace and the `OCIRepository` and `HelmRelease` resources that install the {{< reuse "/agw-docs/snippets/kgateway.md" >}} CRD and control plane charts into it. You might also need the following values:
+   * **Development builds**: `controller.image.pullPolicy=Always` to ensure you get the latest image.
+   * **Experimental Gateway API features**: `controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true` to enable experimental features such as TCPRoutes.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: v1
+   kind: Namespace
+   metadata:
+     name: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   ---
+   apiVersion: source.toolkit.fluxcd.io/v1
+   kind: OCIRepository
+   metadata:
+     name: {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     interval: 5m
+     url: oci://cr.agentgateway.dev/charts/{{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+     ref:
+       tag: {{< reuse "agw-docs/versions/helm-version-flag.md" >}}
+   ---
+   apiVersion: helm.toolkit.fluxcd.io/v2
+   kind: HelmRelease
+   metadata:
+     name: {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     interval: 5m
+     releaseName: {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+     chartRef:
+       kind: OCIRepository
+       name: {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+     upgrade:
+       strategy:
+         name: RetryOnFailure
+         retryInterval: 5m
+   ---
+   apiVersion: source.toolkit.fluxcd.io/v1
+   kind: OCIRepository
+   metadata:
+     name: {{< reuse "/agw-docs/snippets/helm-kgateway.md" >}}
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     interval: 5m
+     url: oci://cr.agentgateway.dev/charts/{{< reuse "/agw-docs/snippets/helm-kgateway.md" >}}
+     ref:
+       tag: {{< reuse "agw-docs/versions/helm-version-flag.md" >}}
+   ---
+   apiVersion: helm.toolkit.fluxcd.io/v2
+   kind: HelmRelease
+   metadata:
+     name: {{< reuse "/agw-docs/snippets/helm-kgateway.md" >}}
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     dependsOn:
+       - name: {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+     interval: 5m
+     releaseName: {{< reuse "/agw-docs/snippets/helm-kgateway.md" >}}
+     chartRef:
+       kind: OCIRepository
+       name: {{< reuse "/agw-docs/snippets/helm-kgateway.md" >}}
+     upgrade:
+       strategy:
+         name: RetryOnFailure
+         retryInterval: 5m
+     values:
+       controller:
+         image:
+           pullPolicy: Always
+         extraEnv:
+           KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES: "true"
+   EOF
+   ```
+
+3. Verify that the `HelmRelease` resources reconcile successfully.
+
+   ```sh
+   kubectl get helmrelease -n {{< reuse "agw-docs/snippets/namespace.md" >}}
+   ```
+
+   Example output:
+   ```txt
+   NAME                AGE   READY   STATUS
+   agentgateway        2m    True    Helm install succeeded for release agentgateway-system/agentgateway.v1
+   agentgateway-crds   2m    True    Helm install succeeded for release agentgateway-system/agentgateway-crds.v1
+   ```
+
+4. Verify that the control plane is up and running.
+
+   ```sh
+   kubectl get pods -n {{< reuse "agw-docs/snippets/namespace.md" >}}
+   ```
+
+   Example output:
+   ```txt
+   NAME                             READY   STATUS    RESTARTS   AGE
+   {{< reuse "agw-docs/snippets/pod-name.md" >}}-6b5bb4db6b-c2pkq   1/1     Running   0          4m4s
+   ```
+
+5. Verify that the `{{< reuse "/agw-docs/snippets/gatewayclass.md" >}}` GatewayClass is created. You can optionally take a look at how the GatewayClass is configured by adding the `-o yaml` option to your command.
+
+   ```sh
+   kubectl get gatewayclass {{< reuse "/agw-docs/snippets/gatewayclass.md" >}}
+   ```
+
+## Next steps
+
+Now that you have {{< reuse "/agw-docs/snippets/kgateway.md" >}} set up and running, check out the following guides to expand your gateway capabilities.
+
+- [Set up your agentgateway proxy]({{< link-hextra path="/setup/gateway/" >}}).
+- Review the [LLM consumption]({{< link-hextra path="/llm/" >}}), [inference routing]({{< link-hextra path="/inference/" >}}), [MCP]({{< link-hextra path="/mcp/" >}}), or [agent connectivity]({{< link-hextra path="/agent/" >}}) guides to learn more about common agentgateway use cases.
+
+## Cleanup
+
+{{< reuse "agw-docs/snippets/cleanup.md" >}}
+
+Follow the [Uninstall with Flux guide]({{< link-hextra path="/operations/uninstall#flux">}}).

--- a/assets/agw-docs/pages/operations/uninstall.md
+++ b/assets/agw-docs/pages/operations/uninstall.md
@@ -5,7 +5,7 @@ If you no longer need your {{< reuse "/agw-docs/snippets/kgateway.md" >}} enviro
 Remove the {{< reuse "/agw-docs/snippets/kgateway.md" >}} control plane and gateway proxies.
 
 {{< callout type="info" >}}
-Did you use Argo CD to install {{< reuse "/agw-docs/snippets/kgateway.md" >}}? Skip to the [Argo CD steps](#argocd).
+Did you use Argo CD to install {{< reuse "/agw-docs/snippets/kgateway.md" >}}? Skip to the [Argo CD steps](#argocd). For Flux installations, skip to the [Flux steps](#flux).
 {{< /callout >}}
 
 1. Get all HTTP routes in your environment. 
@@ -177,4 +177,41 @@ For ArgoCD installations, use the following steps to clean up your environment.
 {{% /tab %}}
 {{< /tabs >}}
 
+## Uninstall with FluxCD {#flux}
+
+If you followed the [Flux installation steps]({{< link-hextra path="/install/flux" >}}) and want to uninstall, use the following steps to undo them. If you instead manage the manifests from a Git or OCI source that Flux reconciles, remove them from that source and let the controllers prune the resources for you.
+
+1. Delete the {{< reuse "/agw-docs/snippets/kgateway.md" >}} `HelmRelease` and `OCIRepository` resources. Flux uninstalls the corresponding Helm releases from the cluster.
+
+   ```sh
+   kubectl delete helmrelease -n {{< reuse "agw-docs/snippets/namespace.md" >}} {{< reuse "/agw-docs/snippets/helm-kgateway.md" >}} {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+   kubectl delete ocirepository -n {{< reuse "agw-docs/snippets/namespace.md" >}} {{< reuse "/agw-docs/snippets/helm-kgateway.md" >}} {{< reuse "/agw-docs/snippets/helm-kgateway-crds.md" >}}
+   ```
+
+2. Verify that the pods were removed from the `{{< reuse "agw-docs/snippets/namespace.md" >}}` namespace.
+
+   ```sh
+   kubectl get pods -n {{< reuse "agw-docs/snippets/namespace.md" >}}
+   ```
+
+   Example output:
+   ```txt
+   No resources found in {{< reuse "agw-docs/snippets/namespace.md" >}} namespace.
+   ```
+
+3. Remove the `{{< reuse "agw-docs/snippets/namespace.md" >}}` namespace.
+
+   ```sh
+   kubectl delete namespace {{< reuse "agw-docs/snippets/namespace.md" >}}
+   ```
+
+4. Delete the Kubernetes Gateway API `Kustomization` and `GitRepository`. Because the `Kustomization` was created with `prune: true`, Flux removes the Gateway API CRDs from the cluster. Then remove the `gateway-api` namespace.
+
+   ```sh
+   kubectl delete kustomization -n gateway-api gateway-api
+   kubectl delete gitrepository -n gateway-api gateway-api
+   kubectl delete namespace gateway-api
+   ```
+
+5. If you no longer need Flux, uninstall it by following the [Flux uninstallation guide](https://fluxcd.io/flux/installation/uninstall/) or, if you installed it with the Flux Operator, the [Flux Operator uninstall guide](https://fluxoperator.dev/docs/guides/install/#uninstall).
 

--- a/content/docs/kubernetes/1.0.x/install/_index.md
+++ b/content/docs/kubernetes/1.0.x/install/_index.md
@@ -10,6 +10,7 @@ Learn how to install the {{< reuse "/agw-docs/snippets/kgateway.md" >}} {{< glos
 {{< cards >}}
   {{< card link="helm" title="Helm" >}}
   {{< card link="argocd" title="Argo CD" >}}
+  {{< card link="flux" title="Flux CD" >}}
   {{< card link="sample-app" title="Sample app" >}}
   {{< card link="advanced" title="Advanced settings" >}}
   {{< card link="tls" title="TLS encryption" >}}

--- a/content/docs/kubernetes/1.0.x/install/flux.md
+++ b/content/docs/kubernetes/1.0.x/install/flux.md
@@ -1,0 +1,8 @@
+---
+title: FluxCD
+weight: 11
+description: Install agentgateway and related components.
+test: skip
+---
+
+{{< reuse "agw-docs/pages/install/flux.md" >}}

--- a/content/docs/kubernetes/2.2.x/install/_index.md
+++ b/content/docs/kubernetes/2.2.x/install/_index.md
@@ -9,6 +9,7 @@ Learn how to install the {{< reuse "/agw-docs/snippets/kgateway.md" >}} {{< glos
 {{< cards >}}
   {{< card link="helm" title="Helm" >}}
   {{< card link="argocd" title="Argo CD" >}}
+  {{< card link="flux" title="Flux CD" >}}
   {{< card link="sample-app" title="Sample app" >}}
   {{< card link="advanced" title="Advanced settings" >}}
   {{< card link="tls" title="TLS encryption" >}}

--- a/content/docs/kubernetes/2.2.x/install/flux.md
+++ b/content/docs/kubernetes/2.2.x/install/flux.md
@@ -1,0 +1,7 @@
+---
+title: FluxCD
+weight: 11
+description: Install kgateway and related components.
+---
+
+{{< reuse "agw-docs/pages/install/flux.md" >}}

--- a/content/docs/kubernetes/latest/install/_index.md
+++ b/content/docs/kubernetes/latest/install/_index.md
@@ -10,6 +10,7 @@ Learn how to install the {{< reuse "/agw-docs/snippets/kgateway.md" >}} {{< glos
 {{< cards >}}
   {{< card link="helm" title="Helm" >}}
   {{< card link="argocd" title="Argo CD" >}}
+  {{< card link="flux" title="Flux CD" >}}
   {{< card link="sample-app" title="Sample app" >}}
   {{< card link="advanced" title="Advanced settings" >}}
   {{< card link="tls" title="TLS encryption" >}}

--- a/content/docs/kubernetes/latest/install/flux.md
+++ b/content/docs/kubernetes/latest/install/flux.md
@@ -1,0 +1,8 @@
+---
+title: FluxCD
+weight: 11
+description: Install agentgateway and related components.
+test: skip
+---
+
+{{< reuse "agw-docs/pages/install/flux.md" >}}

--- a/content/docs/kubernetes/main/install/_index.md
+++ b/content/docs/kubernetes/main/install/_index.md
@@ -10,6 +10,7 @@ Learn how to install the {{< reuse "/agw-docs/snippets/kgateway.md" >}} {{< glos
 {{< cards >}}
   {{< card link="helm" title="Helm" >}}
   {{< card link="argocd" title="Argo CD" >}}
+  {{< card link="flux" title="Flux CD" >}}
   {{< card link="sample-app" title="Sample app" >}}
   {{< card link="advanced" title="Advanced settings" >}}
   {{< card link="tls" title="TLS encryption" >}}

--- a/content/docs/kubernetes/main/install/flux.md
+++ b/content/docs/kubernetes/main/install/flux.md
@@ -1,0 +1,8 @@
+---
+title: FluxCD
+weight: 11
+description: Install agentgateway and related components.
+test: skip
+---
+
+{{< reuse "agw-docs/pages/install/flux.md" >}}


### PR DESCRIPTION
Hello :wave: 

I noticed Flux is mentioned [here](https://agentgateway.dev/docs/standalone/latest/integrations/web-uis/kagent/#what-is-kagent), but a proper installation guide was missing, so I filed this PR :pray: 