### PR TITLE
Inference: Update routing mode docs

### DIFF
--- a/assets/agw-docs/pages/agentgateway/inference.md
+++ b/assets/agw-docs/pages/agentgateway/inference.md
@@ -9,7 +9,7 @@ For more information, see the following resources.
 
 {{< cards >}}
   {{< card link="https://gateway-api-inference-extension.sigs.k8s.io/" title="Kubernetes Gateway API Inference Extension docs" icon="external-link">}}
-  {{< card link="/docs/standalone/main/inference/" title="Standalone inference routing" >}}
+  {{< card link="https://agentgateway.dev/docs/standalone/main/inference/" title="Standalone inference routing" >}}
   {{< card link="https://kgateway.dev/blog/deep-dive-inference-extensions/" title="Kgateway deep-dive blog on Inference Extension" icon="external-link">}}
 {{< /cards >}}
 

--- a/assets/agw-docs/pages/agentgateway/inference.md
+++ b/assets/agw-docs/pages/agentgateway/inference.md
@@ -1,9 +1,15 @@
 Use {{< reuse "agw-docs/snippets/kgateway.md" >}} with the Kubernetes Gateway API Inference Extension to route requests to AI inference workloads, such as Large Language Models (LLMs) that run in your Kubernetes environment.
 
+This page covers Kubernetes Gateway API mode, where agentgateway routes to
+`InferencePool` backends from Gateway API resources. If you want to run the
+Endpoint Picker Extension (EPP) with agentgateway as a standalone sidecar proxy,
+see the standalone request scheduler guide instead.
+
 For more information, see the following resources.
 
 {{< cards >}}
   {{< card link="https://gateway-api-inference-extension.sigs.k8s.io/" title="Kubernetes Gateway API Inference Extension docs" icon="external-link">}}
+  {{< card link="/docs/standalone/main/inference/" title="Standalone inference routing" >}}
   {{< card link="https://kgateway.dev/blog/deep-dive-inference-extensions/" title="Kgateway deep-dive blog on Inference Extension" icon="external-link">}}
 {{< /cards >}}
 

--- a/content/docs/standalone/main/inference/_index.md
+++ b/content/docs/standalone/main/inference/_index.md
@@ -5,8 +5,40 @@ description:
 test: skip
 ---
 
-Refer to the agentgateway on Kubernetes documentation for more information about inference routing. You can also comment or subscribe to [this issue](https://github.com/agentgateway/agentgateway/issues/620) to get updates on the status of inference support in the standalone agentgateway binary.
+Agentgateway supports the Kubernetes Gateway API Inference Extension in two
+deployment modes.
+
+## Kubernetes Gateway API mode
+
+In Kubernetes Gateway API mode, agentgateway runs as the gateway data plane for
+Gateway API resources. You install the Inference Extension CRDs, create an
+`InferencePool`, and route to that pool from an `HTTPRoute`. The Endpoint Picker
+Extension (EPP) acts as an extension service that selects the best model server
+endpoint for each inference request.
+
+Use this mode when you want Gateway API integration, `InferencePool` resources,
+traffic splitting, route matching, and other Kubernetes networking features.
 
 {{< cards>}}
-  {{< card link="/docs/kubernetes/main/inference/" title="Inference routing" >}}
+  {{< card link="/docs/kubernetes/main/inference/" title="Set up Kubernetes inference routing" >}}
+{{< /cards >}}
+
+## Standalone request scheduler mode
+
+In standalone request scheduler mode, agentgateway runs as a sidecar proxy with
+the EPP. The proxy and EPP communicate over localhost, and agentgateway uses its
+standalone `inferenceRouting` local configuration to route requests to a
+Kubernetes `Service` before consulting the EPP for endpoint selection.
+
+Use this mode for single-tenant or job-scoped workloads where deploying a full
+Gateway API stack would add unnecessary operational overhead. In this mode, the
+upstream standalone Helm chart can deploy agentgateway as the sidecar proxy with
+`proxyType: agentgateway`.
+
+Standalone request scheduler mode does not support `InferencePool`. The model
+workload must have a Kubernetes `Service`, and the chart-generated service ports
+must match the EPP target ports.
+
+{{< cards>}}
+  {{< card link="https://gateway-api-inference-extension.sigs.k8s.io/guides/standalone/#deploy-as-a-standalone-request-scheduler" title="Deploy a standalone request scheduler" icon="external-link" >}}
 {{< /cards >}}


### PR DESCRIPTION
## Summary
- Update existing standalone routing doc with real content now that this mode is supported.
- Reference the standalone doc from the Kubernetes mode inference routing doc.