### PR TITLE
Fix standalone inference guide

### DIFF
--- a/content/docs/standalone/main/inference/_index.md
+++ b/content/docs/standalone/main/inference/_index.md
@@ -29,16 +29,49 @@ traffic splitting, route matching, and other Kubernetes networking features.
 In standalone request scheduler mode, agentgateway runs as a sidecar proxy with
 the EPP. The proxy and EPP communicate over localhost, and agentgateway uses its
 standalone `inferenceRouting` local configuration to route requests to a
-Kubernetes `Service` before consulting the EPP for endpoint selection.
+synthetic service before consulting the EPP for endpoint selection.
 
 Use this mode for single-tenant or job-scoped workloads where deploying a full
 Gateway API stack would add unnecessary operational overhead. In this mode, the
 upstream standalone Helm chart can deploy agentgateway as the sidecar proxy with
 `proxyType: agentgateway`.
 
-Standalone request scheduler mode does not support `InferencePool`. The model
-workload must have a Kubernetes `Service`, and the chart-generated service ports
-must match the EPP target ports.
+Standalone request scheduler mode does not support `InferencePool`. The
+standalone configuration must define a top-level synthetic service, such as a
+`services` entry, and the route backend must reference that service. When EPP
+owns endpoint discovery, set `destinationMode: passthrough` so EPP-selected
+destinations can be forwarded to directly without matching local workload
+endpoint data.
+
+For example, the standalone agentgateway configuration defines the synthetic
+service in `services`, and the route backend references it as
+`default/my-model`.
+
+```yaml
+services:
+- name: my-model
+  namespace: default
+  hostname: my-model
+  vips: []
+  ports:
+    8000: 8000
+
+binds:
+- port: 8081
+  listeners:
+  - routes:
+    - backends:
+      - service:
+          name: default/my-model
+          port: 8000
+        policies:
+          inferenceRouting:
+            endpointPicker:
+              host: 127.0.0.1:9002
+            destinationMode: passthrough
+```
+
+For more examples, see the [standalone EPP example](https://github.com/agentgateway/agentgateway/blob/main/examples/standalone-epp/README.md).
 
 {{< cards>}}
   {{< card link="https://gateway-api-inference-extension.sigs.k8s.io/guides/standalone/#deploy-as-a-standalone-request-scheduler" title="Deploy a standalone request scheduler" icon="external-link" >}}


### PR DESCRIPTION
- Clarify standalone inference routing uses a synthetic service, not a Kubernetes Service.
- Document `destinationMode: passthrough` for EPP-owned endpoint discovery.
- Add a compact standalone EPP config example and upstream example link.
