### PR TITLE
AI readiness scorecard improvements

### DIFF
--- a/content/docs/kubernetes/1.0.x/_index.md
+++ b/content/docs/kubernetes/1.0.x/_index.md
@@ -5,6 +5,7 @@ description: Use agentgateway in a Kubernetes environment.
 test: skip
 cascade:
   excludeSearch: true
+  llms: false
 ---
 
 Welcome to the documentation for using agentgateway on Kubernetes!

--- a/content/docs/kubernetes/2.2.x/_index.md
+++ b/content/docs/kubernetes/2.2.x/_index.md
@@ -4,6 +4,7 @@ weight: 460
 description: Use agentgateway in a Kubernetes environment. 
 cascade:
   excludeSearch: true
+  llms: false
 ---
 
 Welcome to the documentation for using agentgateway on Kubernetes!

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,7 +6,7 @@ title: "agentgateway | Agent Connectivity Solved"
 outputs:
   home: [HTML, RSS, llms]
   page: [HTML, markdown]
-  section: [HTML, RSS, markdown]
+  section: [HTML, RSS, markdown, llms]
 
 defaultContentLanguage: en
 

--- a/layouts/_default/section.llms.txt
+++ b/layouts/_default/section.llms.txt
@@ -1,0 +1,33 @@
+# {{ .Title }}
+{{ with .Description }}
+> {{ . }}
+{{ end }}
+{{- $depth := len (findRE "[^/]+" .RelPermalink) -}}
+{{- if and .Sections (lt $depth 3) }}
+{{- /* Intermediate section (docs, docs/kubernetes): list subsection llms.txt links */}}
+{{ range where .Sections "Params.llms" "ne" false }}
+- [{{ .Title }}]({{ print "https://agentgateway.dev" .RelPermalink }}llms.txt)
+{{- end }}
+
+{{- else }}
+{{- /* Content section (version dirs and leaf sections): full page listing */}}
+{{- template "llms-section-full-tree" dict "context" . "level" 2 }}
+{{- end }}
+
+---
+Generated on {{ now.Format "2006-01-02 15:04:05 UTC" }}
+
+{{- define "llms-section-full-tree" -}}
+{{- $context := .context -}}
+{{- $level := .level | default 2 -}}
+{{- $hashes := strings.Repeat $level "#" -}}
+
+{{- range where $context.RegularPages "Params.llms" "ne" false }}
+- [{{ .Title }}]({{ print "https://agentgateway.dev" .RelPermalink }}): {{ .Summary | plainify | truncate 100 | strings.TrimSpace }}{{ if .Date }} - Published {{ .Date.Format "2006-01-02" }}{{ end }}
+{{- end }}
+
+{{- range where $context.Sections "Params.llms" "ne" false }}
+{{ "\n" }}{{ $hashes }} {{ .Title }}
+{{ template "llms-section-full-tree" dict "context" . "level" (add $level 1) }}
+{{- end }}
+{{- end -}}

--- a/layouts/llms.txt
+++ b/layouts/llms.txt
@@ -2,34 +2,38 @@
 
 > {{ .Site.Params.description | default "" }}
 
+This is the root documentation index. For detailed page listings, follow the section links below.
+
 {{ range where site.Sections "Params.llms" "ne" false }}
-{{- template "llms-section-tree" dict "context" . "level" 2 }}
+{{- template "llms-root-index-tree" dict "context" . "level" 2 }}
 {{ end }}
-
-{{- $rootPages := where (where site.RegularPages "Section" "") "Params.llms" "ne" false }}
-{{- if $rootPages }}
-## Root Pages
-{{- range $rootPages }}
-- [{{ .Title }}]({{ print "https://agentgateway.dev" .RelPermalink }}): {{ .Summary | plainify | truncate 100 | strings.TrimSpace }}{{ if .Date }} - Published {{ .Date.Format "2006-01-02" }}{{ end }}
-{{- end }}
-{{- end }}
-
 ---
 Generated on {{ now.Format "2006-01-02 15:04:05 UTC" }}
 Site: https://agentgateway.dev
 
-{{- define "llms-section-tree" -}}
-{{- $context := .context -}}
+{{- define "llms-root-index-tree" -}}
+{{- $s := .context -}}
 {{- $level := .level | default 2 -}}
-{{- $headerHashes := strings.Repeat $level "#" -}}
-{{- "\n" -}}
-{{ $headerHashes }} {{ $context.Title }}
+{{- $depth := len (findRE "[^/]+" $s.RelPermalink) -}}
+{{- $hashes := strings.Repeat $level "#" -}}
 
-{{- range where $context.RegularPages "Params.llms" "ne" false }}
+{{- if not $s.Sections }}
+{{- /* Leaf section (e.g. blog, tutorials): inline pages */}}
+{{ "\n" }}{{ $hashes }} {{ $s.Title }}
+{{- range where $s.RegularPages "Params.llms" "ne" false }}
 - [{{ .Title }}]({{ print "https://agentgateway.dev" .RelPermalink }}): {{ .Summary | plainify | truncate 100 | strings.TrimSpace }}{{ if .Date }} - Published {{ .Date.Format "2006-01-02" }}{{ end }}
 {{- end }}
 
-{{- range where $context.Sections "Params.llms" "ne" false }}
-{{ template "llms-section-tree" dict "context" . "level" (add $level 1) }}
+{{- else if ge $depth 3 }}
+{{- /* Version-level section (e.g. docs/kubernetes/1.0.x): link to its llms.txt */}}
+- [{{ $s.Title }}]({{ print "https://agentgateway.dev" $s.RelPermalink }}llms.txt)
+
+{{- else }}
+{{- /* Intermediate section (e.g. docs, docs/kubernetes): add header and recurse */}}
+{{ "\n" }}{{ $hashes }} {{ $s.Title }}
+{{- range where $s.Sections "Params.llms" "ne" false }}
+{{ template "llms-root-index-tree" dict "context" . "level" (add $level 1) }}
+{{- end }}
+
 {{- end }}
 {{- end -}}

--- a/layouts/llms.txt
+++ b/layouts/llms.txt
@@ -1,0 +1,35 @@
+# {{ .Site.Title }}
+
+> {{ .Site.Params.description | default "" }}
+
+{{ range where site.Sections "Params.llms" "ne" false }}
+{{- template "llms-section-tree" dict "context" . "level" 2 }}
+{{ end }}
+
+{{- $rootPages := where (where site.RegularPages "Section" "") "Params.llms" "ne" false }}
+{{- if $rootPages }}
+## Root Pages
+{{- range $rootPages }}
+- [{{ .Title }}]({{ print "https://agentgateway.dev" .RelPermalink }}): {{ .Summary | plainify | truncate 100 | strings.TrimSpace }}{{ if .Date }} - Published {{ .Date.Format "2006-01-02" }}{{ end }}
+{{- end }}
+{{- end }}
+
+---
+Generated on {{ now.Format "2006-01-02 15:04:05 UTC" }}
+Site: https://agentgateway.dev
+
+{{- define "llms-section-tree" -}}
+{{- $context := .context -}}
+{{- $level := .level | default 2 -}}
+{{- $headerHashes := strings.Repeat $level "#" -}}
+{{- "\n" -}}
+{{ $headerHashes }} {{ $context.Title }}
+
+{{- range where $context.RegularPages "Params.llms" "ne" false }}
+- [{{ .Title }}]({{ print "https://agentgateway.dev" .RelPermalink }}): {{ .Summary | plainify | truncate 100 | strings.TrimSpace }}{{ if .Date }} - Published {{ .Date.Format "2006-01-02" }}{{ end }}
+{{- end }}
+
+{{- range where $context.Sections "Params.llms" "ne" false }}
+{{ template "llms-section-tree" dict "context" . "level" (add $level 1) }}
+{{- end }}
+{{- end -}}

--- a/layouts/page.markdown.md
+++ b/layouts/page.markdown.md
@@ -1,0 +1,4 @@
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of all pages are available by appending .md to any docs URL.
+
+# {{- .Title | replaceRE "\n" " " }}
+{{ .RawContent }}

--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,3 +1,8 @@
+{{/* llms.txt agent directive */}}
+<div style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap">
+  For the complete documentation index, see <a href="/llms.txt">llms.txt</a>.
+  Markdown versions of pages are available by appending .md to any page URL.
+</div>
 {{/* Google Tag Manager */}}
 <script>
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/layouts/section.markdown.md
+++ b/layouts/section.markdown.md
@@ -1,0 +1,4 @@
+> For the complete documentation index, see [llms.txt](/llms.txt). Markdown versions of all pages are available by appending .md to any docs URL.
+
+# {{- .Title | replaceRE "\n" " " }}
+{{ .RawContent }}


### PR DESCRIPTION
1. Add llms.txt directive to `layouts/partials/custom/head-end.html`
    Fixes: llms-txt-directive-html FAIL (+big points in Content Discoverability)

2. Add llms.txt directive to Markdown output in `layouts/page.markdown.md` and `layouts/section.markdown.md`
    Fixes: llms-txt-directive-md FAIL (+big points in Content Discoverability)

3. Fix llms.txt to emit absolute URLs in `layouts/llms.txt`
    Fixes: llms-txt-links-resolve and llms-txt-links-markdown (both currently SKIP — "No HTTP(S) links found")

4. Split llms.txt into section-level files. The root llms.txt will provide connections to these files.
    Fixes: llms-txt-size FAIL (159K chars → must be under 100K)
    ```
    ### Agentgateway on Kubernetes
    - [Latest](https://agentgateway.dev/docs/kubernetes/latest/llms.txt)
    - [Main (in dev)](https://agentgateway.dev/docs/kubernetes/main/llms.txt)
    
    ### Standalone binary docs
    - [Latest](https://agentgateway.dev/docs/standalone/latest/llms.txt)
    - [Main (dev)](https://agentgateway.dev/docs/standalone/main/llms.txt)
    ```

