### PR TITLE
Create a release blog template

### DIFF
--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -14,7 +14,7 @@ Replace this introduction with a short summary of the release. Keep it to 1-2 pa
 
 Agentgateway added a number of exciting features in v1.x.x. You can find the full list of new features in the [release notes](https://agentgateway.dev/docs/kubernetes/main/reference/release-notes/).
 
-### <New Feature 1>
+### <New feature 1>
 
 Short description of the new feature and why a user would adopt it.
 

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -10,7 +10,7 @@ Replace this introduction with a short summary of the release. Keep it to 1-2 pa
 
 ---
 
-## New Feature Highlights
+## New feature highlights
 
 Agentgateway added a number of exciting features in v1.x.x. You can find the full list of new features in the [release notes](https://agentgateway.dev/docs/kubernetes/main/reference/release-notes/).
 

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -36,7 +36,7 @@ Agentgateway v1.x.x is available for download on [GitHub](https://github.com/age
 
 To get started with agentgateway, check out our getting started guide for [standalone](https://agentgateway.dev/docs/standalone/latest/quickstart/) or [Kubernetes](https://agentgateway.dev/docs/kubernetes/latest/quickstart/).
 
-## Get Involved
+## Get involved
 
 <!--THIS COMMUNITY LIVES BY ITS GREAT COMMUNITY, GET THEM INVOLVED! -->
 The simplest way to get involved with agentgateway is by joining our [Discord](https://discord.gg/BdJpzaPjHv) and [community meetings](https://calendar.google.com/calendar/u/0?cid=Y18zZTAzNGE0OTFiMGUyYzU2OWI1Y2ZlOWNmOWM4NjYyZTljNTNjYzVlOTdmMjdkY2I5ZTZmNmM5ZDZhYzRkM2ZmQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -26,7 +26,7 @@ For more information, check out the docs and include link.
 
 Include links to docs or examples when they help readers adopt the feature.
 
-### <New Feature 3>
+### <New feature 3>
 
 Include links to docs or examples when they help readers adopt the feature.
 

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -5,7 +5,7 @@ author: "" # replace with authors of release blog
 description: "agentgateway v1.x.x is here! Here are the highlights."
 ---
 
-// <INTRO>
+<!--INTRO-->
 Replace this introduction with a short summary of the release. Keep it to 1-2 paragraphs and explain why this version matters to users.
 
 ---

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -38,7 +38,7 @@ To get started with agentgateway, check out our getting started guide for [stand
 
 ## Get Involved
 
-<THIS COMMUNITY LIVES BY ITS GREAT COMMUNITY, GET THEM INVOLVED!>
+<!--THIS COMMUNITY LIVES BY ITS GREAT COMMUNITY, GET THEM INVOLVED! -->
 The simplest way to get involved with agentgateway is by joining our [Discord](https://discord.gg/BdJpzaPjHv) and [community meetings](https://calendar.google.com/calendar/u/0?cid=Y18zZTAzNGE0OTFiMGUyYzU2OWI1Y2ZlOWNmOWM4NjYyZTljNTNjYzVlOTdmMjdkY2I5ZTZmNmM5ZDZhYzRkM2ZmQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
 
 ## Contributors

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -16,7 +16,11 @@ Agentgateway added a number of exciting features in v1.x.x. You can find the ful
 
 ### <New Feature 1>
 
-Include links to docs or examples when they help readers adopt the feature.
+Short description of the new feature and why a user would adopt it.
+
+If helpful, provide an example, before/after, command or code block, configuration, screenshot, diagram, or similar.
+
+For more information, check out the docs and include link.
 
 ### <New Feature 2>
 

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -1,0 +1,45 @@
+---
+title: "Release v1.x.x: <fun title here>"
+publishDate: 2222-22-22 # replace with date of release
+author: "" # replace with authors of release blog
+description: "agentgateway v1.x.x is here! Here are the highlights."
+---
+
+// <INTRO>
+Replace this introduction with a short summary of the release. Keep it to 1-2 paragraphs and explain why this version matters to users.
+
+---
+
+## New Feature Highlights
+
+Agentgateway added a number of exciting features in v1.x.x. You can find the full list of new features in the [release notes](https://agentgateway.dev/docs/kubernetes/main/reference/release-notes/).
+
+### <New Feature 1>
+
+Include links to docs or examples when they help readers adopt the feature.
+
+### <New Feature 2>
+
+Include links to docs or examples when they help readers adopt the feature.
+
+### <New Feature 3>
+
+Include links to docs or examples when they help readers adopt the feature.
+
+## Availability
+
+Agentgateway v1.x.x is available for download on [GitHub](https://github.com/agentgateway/agentgateway/releases).
+
+To get started with agentgateway, check out our getting started guide for [standalone](https://agentgateway.dev/docs/standalone/latest/quickstart/) or [Kubernetes](https://agentgateway.dev/docs/kubernetes/latest/quickstart/).
+
+## Get Involved
+
+<THIS COMMUNITY LIVES BY ITS GREAT COMMUNITY, GET THEM INVOLVED!>
+The simplest way to get involved with agentgateway is by joining our [Discord](https://discord.gg/BdJpzaPjHv) and [community meetings](https://calendar.google.com/calendar/u/0?cid=Y18zZTAzNGE0OTFiMGUyYzU2OWI1Y2ZlOWNmOWM4NjYyZTljNTNjYzVlOTdmMjdkY2I5ZTZmNmM5ZDZhYzRkM2ZmQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+
+## Contributors
+
+<CHECKOUT THE DEVSTATS AND HIGHLIGHT SOME INTRESTING NUMBERS>
+
+Example:
+Thanks to the X contributors who worked on agentgateway between the previous <PREVIOUS_RELEASE> release and <CURRENT_RELEASE>, as well as the [X contributors](https://github.com/agentgateway/agentgateway/graphs/contributors) who have been with us since we began this journey!

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -43,7 +43,7 @@ The simplest way to get involved with agentgateway is by joining our [Discord](h
 
 ## Contributors
 
-<CHECKOUT THE DEVSTATS AND HIGHLIGHT SOME INTRESTING NUMBERS>
+<!--CHECKOUT THE DEVSTATS AND HIGHLIGHT SOME INTRESTING NUMBERS>
 
-Example:
+Example: -->
 Thanks to the X contributors who worked on agentgateway between the previous <PREVIOUS_RELEASE> release and <CURRENT_RELEASE>, as well as the [X contributors](https://github.com/agentgateway/agentgateway/graphs/contributors) who have been with us since we began this journey!

--- a/content/blog/release-blog-template.md
+++ b/content/blog/release-blog-template.md
@@ -22,7 +22,7 @@ If helpful, provide an example, before/after, command or code block, configurati
 
 For more information, check out the docs and include link.
 
-### <New Feature 2>
+### <New feature 2>
 
 Include links to docs or examples when they help readers adopt the feature.
 


### PR DESCRIPTION
Based on the Kubernetes release blog template we used in sig-release: https://github.com/kubernetes/sig-release/blob/master/release-team/role-handbooks/communications/templates/release-blog.md 

Prerequisite for https://github.com/agentgateway/website/issues/445 