### PR TITLE
Added not in this version page

### DIFF
--- a/assets/agw-docs/pages/not-in-version.md
+++ b/assets/agw-docs/pages/not-in-version.md
@@ -1,7 +1,5 @@
-The topic you tried to switch to isn't available in this version of the documentation.
-
 To find what you need, you can:
 
 - [Browse this version's home page]({{< link-hextra path="/" >}}).
 - Use the **Back** button to return to the previous page.
-- Use the version dropdown above to switch to another version that has this topic.
+- Use the version dropdown to switch to another version that has this topic.

--- a/assets/agw-docs/pages/not-in-version.md
+++ b/assets/agw-docs/pages/not-in-version.md
@@ -1,0 +1,7 @@
+The topic you tried to switch to isn't available in this version of the documentation.
+
+To find what you need, you can:
+
+- [Browse this version's home page]({{< link-hextra path="/" >}}).
+- Use the **Back** button to return to the previous page.
+- Use the version dropdown above to switch to another version that has this topic.

--- a/content/docs/kubernetes/latest/not-in-version.md
+++ b/content/docs/kubernetes/latest/not-in-version.md
@@ -1,0 +1,9 @@
+---
+title: Topic not available in this version
+description: This topic isn't available in this version of the documentation.
+test: skip
+build:
+  list: never
+---
+
+{{< reuse "agw-docs/pages/not-in-version.md" >}}

--- a/content/docs/kubernetes/main/not-in-version.md
+++ b/content/docs/kubernetes/main/not-in-version.md
@@ -1,0 +1,9 @@
+---
+title: Topic not available in this version
+description: This topic isn't available in this version of the documentation.
+test: skip
+build:
+  list: never
+---
+
+{{< reuse "agw-docs/pages/not-in-version.md" >}}

--- a/content/docs/standalone/latest/not-in-version.md
+++ b/content/docs/standalone/latest/not-in-version.md
@@ -1,0 +1,9 @@
+---
+title: Topic not available in this version
+description: This topic isn't available in this version of the documentation.
+test: skip
+build:
+  list: never
+---
+
+{{< reuse "agw-docs/pages/not-in-version.md" >}}

--- a/content/docs/standalone/main/not-in-version.md
+++ b/content/docs/standalone/main/not-in-version.md
@@ -1,0 +1,9 @@
+---
+title: Topic not available in this version
+description: This topic isn't available in this version of the documentation.
+test: skip
+build:
+  list: never
+---
+
+{{< reuse "agw-docs/pages/not-in-version.md" >}}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -510,7 +510,20 @@
               {{- $filtered := after 4 $segments -}}
               {{- $newPath := printf "/%s" (delimit $filtered "/") -}}
               {{- range $versions -}}
-                <a href="/docs/{{ $subSection }}/{{ .linkVersion }}{{ $newPath }}" class="px-4 py-3 block text-left">{{ .dropdown }}</a>
+                {{- /* Default: same path in target version. If that page does not exist
+                       and the target version has a not-in-version fallback page, route
+                       there so the user lands on a helpful page instead of a 404.
+                       Versions without the fallback wrapper keep the existing behavior
+                       (no regression). */ -}}
+                {{- $href := printf "/docs/%s/%s%s" $subSection .linkVersion $newPath -}}
+                {{- $targetPath := printf "/docs/%s/%s%s" $subSection .linkVersion $newPath -}}
+                {{- if not (site.GetPage $targetPath) -}}
+                  {{- $fallbackPath := printf "/docs/%s/%s/not-in-version" $subSection .linkVersion -}}
+                  {{- if site.GetPage $fallbackPath -}}
+                    {{- $href = printf "/docs/%s/%s/not-in-version/" $subSection .linkVersion -}}
+                  {{- end -}}
+                {{- end -}}
+                <a href="{{ $href }}" class="px-4 py-3 block text-left">{{ .dropdown }}</a>
               {{- end -}}
             </div>
           </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -168,7 +168,16 @@
                 {{- $newPath := printf "/%s" (delimit $filtered "/") -}}
                 {{- range $versions -}}
                   {{- $isActive := eq $currentVersion .linkVersion -}}
-                  <a href="/docs/{{ $section }}/{{ .linkVersion }}{{ $newPath }}"
+                  {{- /* See nav.html for the rationale on the not-in-version fallback. */ -}}
+                  {{- $href := printf "/docs/%s/%s%s" $section .linkVersion $newPath -}}
+                  {{- $targetPath := printf "/docs/%s/%s%s" $section .linkVersion $newPath -}}
+                  {{- if not (site.GetPage $targetPath) -}}
+                    {{- $fallbackPath := printf "/docs/%s/%s/not-in-version" $section .linkVersion -}}
+                    {{- if site.GetPage $fallbackPath -}}
+                      {{- $href = printf "/docs/%s/%s/not-in-version/" $section .linkVersion -}}
+                    {{- end -}}
+                  {{- end -}}
+                  <a href="{{ $href }}"
                      style="padding: 0.375rem 0.75rem; border-radius: 0.375rem; font-size: 0.75rem; font-weight: 500; {{ if $isActive }}background: rgb(229 231 235); color: rgb(17 24 39);{{ else }}color: rgb(107 114 128);{{ end }}"
                      class="{{ if $isActive }}hx:dark:bg-gray-700 hx:dark:text-white{{ else }}hx:hover:bg-gray-100 hx:dark:text-gray-400 hx:dark:hover:bg-gray-800{{ end }}">
                     {{ .dropdown }}


### PR DESCRIPTION
Adds a "Topic not available in this version" fallback page so that switching versions on a topic that doesn't exist in the target version lands on a helpful page instead of a 404.

For example, this topic is available in main:
https://kkb-not-in-version-page.agentproxy.pages.dev/docs/kubernetes/main/traffic-management/locality-aware-routing/

But when you switch it to latest, you'll be redirected to the new page, but still remain in the context of the version you selected.