### PR TITLE
fix: broaden session routing docs to apply to all upstream types

### DIFF
--- a/content/docs/kubernetes/latest/reference/release-notes.md
+++ b/content/docs/kubernetes/latest/reference/release-notes.md
@@ -68,7 +68,7 @@ Authorization policies now support `Require` as an action in addition to `Allow`
 
 ### MCP improvements
 
-- **Stateless sessions**: OpenAPI and SSE upstreams can now use stateless sessions. For more information, see [Stateful MCP]({{< link-hextra path="/mcp/session/" >}}).
+- **Stateless sessions**: MCP upstreams can now use stateless sessions. For more information, see [Stateful MCP]({{< link-hextra path="/mcp/session/" >}}).
 - **Explicit service reference lists**: MCP backends can specify targets with explicit service references. For more information, see [Static MCP]({{< link-hextra path="/mcp/static-mcp/" >}}).
 - **Tool payloads in CEL context**: Tool names and payloads are available in logging CEL expressions.
 

--- a/content/docs/standalone/latest/configuration/backends.md
+++ b/content/docs/standalone/latest/configuration/backends.md
@@ -47,7 +47,7 @@ backends:
 
 ### Session routing
 
-By default, MCP backends use stateful session routing, where the gateway tracks session IDs and routes subsequent requests to the same upstream. For OpenAPI and SSE upstreams that do not maintain server-side session state, you can set `statefulMode: Stateless`. In stateless mode, the gateway automatically wraps each request with an initialization sequence, so the upstream server processes every request independently.
+By default, MCP backends use stateful session routing, where the gateway tracks session IDs and routes subsequent requests to the same upstream. For upstreams that do not maintain server-side session state, you can set `statefulMode: Stateless`. In stateless mode, the gateway automatically wraps each request with an initialization sequence, so the upstream server processes every request independently.
 
 ```yaml
 backends:

--- a/content/docs/standalone/latest/reference/release-notes.md
+++ b/content/docs/standalone/latest/reference/release-notes.md
@@ -76,7 +76,7 @@ For more information, see [HTTP authorization]({{< link-hextra path="/configurat
 
 ### MCP improvements
 
-- **Stateless sessions**: OpenAPI and SSE upstreams can now use stateless sessions, avoiding state persistence for backends that don't need it. For more information, see [OpenAPI connectivity]({{< link-hextra path="/mcp/connect/openapi/" >}}) and [Backends]({{< link-hextra path="/configuration/backends/" >}}).
+- **Stateless sessions**: MCP upstreams can now use stateless sessions, avoiding state persistence for backends that don't need it. For more information, see [OpenAPI connectivity]({{< link-hextra path="/mcp/connect/openapi/" >}}) and [Backends]({{< link-hextra path="/configuration/backends/" >}}).
 - **Explicit service reference lists**: MCP backends can specify targets with explicit service references.
 - **Tool payloads in CEL context**: Tool names and payloads are available in logging CEL expressions via `mcp.tool.name` and other `mcp.tool.*` fields.
 

--- a/content/docs/standalone/main/configuration/backends.md
+++ b/content/docs/standalone/main/configuration/backends.md
@@ -47,7 +47,7 @@ backends:
 
 ### Session routing
 
-By default, MCP backends use stateful session routing, where the gateway tracks session IDs and routes subsequent requests to the same upstream. For OpenAPI and SSE upstreams that do not maintain server-side session state, you can set `statefulMode: Stateless`. In stateless mode, the gateway automatically wraps each request with an initialization sequence, so the upstream server processes every request independently.
+By default, MCP backends use stateful session routing, where the gateway tracks session IDs and routes subsequent requests to the same upstream. For upstreams that do not maintain server-side session state, you can set `statefulMode: Stateless`. In stateless mode, the gateway automatically wraps each request with an initialization sequence, so the upstream server processes every request independently.
 
 ```yaml
 backends:


### PR DESCRIPTION
Remove incorrect limitation of stateless session routing to 'OpenAPI and SSE upstreams'. Session routing (stateful and stateless) works with all MCP upstream types, not just OpenAPI and SSE.

closes https://github.com/solo-io/docs/issues/2426