### PR TITLE
agw-standalone feedback: security/backend-tls - clarify service ide...

### DIFF
--- a/assets/agw-docs/pages/security/backendtls.md
+++ b/assets/agw-docs/pages/security/backendtls.md
@@ -116,7 +116,7 @@ Create a BackendTLSPolicy for the NGINX workload.
    | Setting | Description |
    |---------|-------------|
    | `targetRefs` | The service that you want the Gateway to originate a TLS connection to, such as the NGINX server. <br><br>**Agentgateway proxies**: Even if you use a Backend for selector-based destinations, you still need to target the backing Service and the `sectionName` of the port that you want the policy to apply to.  |
-   | `validation.hostname` | The hostname that matches the NGINX server certificate. |
+   | `validation.hostname` | The hostname that matches the NGINX server certificate. The gateway verifies this hostname against the Subject Alternative Names (SANs) or Common Name (CN) in the server certificate. |
    | `validation.caCertificateRefs` | The ConfigMap that has the certificate used to verify the backend. For the NGINX deployment in this guide, the server uses a self-signed certificate, so use that same certificate as the trust anchor. |
 
 3. Create an HTTPRoute that routes traffic to the NGINX server on the `example.com` hostname and HTTPS port 8443. Note that the parent Gateway is the sample `http` Gateway resource that you created [before you began](#before-you-begin).

--- a/content/docs/standalone/latest/configuration/security/backend-tls.md
+++ b/content/docs/standalone/latest/configuration/security/backend-tls.md
@@ -29,10 +29,13 @@ backendTLS:
 
 ## Subject Alternative Names
 
-When connecting to upstream services over TLS, you can specify expected Subject Alternative Names (SANs) to verify. The upstream certificate must contain at least one SAN that matches the configured list. In Kubernetes environments, Service SANs are automatically populated from the service identity.
+When connecting to upstream services over TLS, you can specify expected Subject Alternative Names (SANs) to verify. The upstream certificate must contain at least one SAN that matches the configured list.
+
+By default, agentgateway uses the service hostname for verification (the Kubernetes service hostname or backend static hostname). You can override this by configuring the `subjectAltNames` field with specific values to match.
 
 ```yaml
 backendTLS:
   subjectAltNames:
-  - "spiffe://cluster.local/ns/default/sa/my-service"
+  - "my-upstream-service.example.com"
+  - "another-valid-san.example.com"
 ```

--- a/content/docs/standalone/latest/configuration/security/backend-tls.md
+++ b/content/docs/standalone/latest/configuration/security/backend-tls.md
@@ -17,25 +17,8 @@ backendTLS:
   cert: ./certs/cert.pem
   # For mutual TLS, the client certificate key to use.
   key: ./certs/key.pem
-  # Expected Subject Alternative Names (SANs) for certificate verification.
-  # If set, the upstream certificate must contain at least one matching SAN.
-  # subjectAltNames:
-  # - "spiffe://cluster.local/ns/default/sa/my-service"
   # If set, hostname verification is disabled
   # insecureHost: true
   # If set, all TLS verification is disabled
   # insecure: true
-```
-
-## Subject Alternative Names
-
-When connecting to upstream services over TLS, you can specify expected Subject Alternative Names (SANs) to verify. The upstream certificate must contain at least one SAN that matches the configured list.
-
-By default, agentgateway uses the service hostname for verification (the Kubernetes service hostname or backend static hostname). You can override this by configuring the `subjectAltNames` field with specific values to match.
-
-```yaml
-backendTLS:
-  subjectAltNames:
-  - "my-upstream-service.example.com"
-  - "another-valid-san.example.com"
 ```

--- a/content/docs/standalone/main/configuration/security/backend-tls.md
+++ b/content/docs/standalone/main/configuration/security/backend-tls.md
@@ -29,10 +29,13 @@ backendTLS:
 
 ## Subject Alternative Names
 
-When connecting to upstream services over TLS, you can specify expected Subject Alternative Names (SANs) to verify. The upstream certificate must contain at least one SAN that matches the configured list. In Kubernetes environments, Service SANs are automatically populated from the service identity.
+When connecting to upstream services over TLS, you can specify expected Subject Alternative Names (SANs) to verify. The upstream certificate must contain at least one SAN that matches the configured list.
+
+By default, agentgateway uses the service hostname for verification (the Kubernetes service hostname or backend static hostname). You can override this by configuring the `subjectAltNames` field with specific values to match.
 
 ```yaml
 backendTLS:
   subjectAltNames:
-  - "spiffe://cluster.local/ns/default/sa/my-service"
+  - "my-upstream-service.example.com"
+  - "another-valid-san.example.com"
 ```

--- a/content/docs/standalone/main/configuration/security/backend-tls.md
+++ b/content/docs/standalone/main/configuration/security/backend-tls.md
@@ -17,25 +17,8 @@ backendTLS:
   cert: ./certs/cert.pem
   # For mutual TLS, the client certificate key to use.
   key: ./certs/key.pem
-  # Expected Subject Alternative Names (SANs) for certificate verification.
-  # If set, the upstream certificate must contain at least one matching SAN.
-  # subjectAltNames:
-  # - "spiffe://cluster.local/ns/default/sa/my-service"
   # If set, hostname verification is disabled
   # insecureHost: true
   # If set, all TLS verification is disabled
   # insecure: true
-```
-
-## Subject Alternative Names
-
-When connecting to upstream services over TLS, you can specify expected Subject Alternative Names (SANs) to verify. The upstream certificate must contain at least one SAN that matches the configured list.
-
-By default, agentgateway uses the service hostname for verification (the Kubernetes service hostname or backend static hostname). You can override this by configuring the `subjectAltNames` field with specific values to match.
-
-```yaml
-backendTLS:
-  subjectAltNames:
-  - "my-upstream-service.example.com"
-  - "another-valid-san.example.com"
 ```


### PR DESCRIPTION
Fixed misleading documentation about backend TLS service identity behavior in standalone mode.

Closes [#2432](https://github.com/solo-io/docs/issues/2432)