### PR TITLE
reference/cel: add a statement about streaming responses

### DIFF
--- a/content/docs/standalone/latest/reference/cel/variables.md
+++ b/content/docs/standalone/latest/reference/cel/variables.md
@@ -18,7 +18,7 @@ For the full list of fields and types on every top-level object, see the [CEL re
 
 ## Variables by policy type
 
-Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields. Evaluation of response body attributes or llm response info can be inconsistent when using streaming responses.
+Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields. Note that when using streaming responses, the evaluation of response body attributes or LLM response information can be inconsistent.
 
 | Policy | Available top-level variables |
 |--------|------------------------------|

--- a/content/docs/standalone/latest/reference/cel/variables.md
+++ b/content/docs/standalone/latest/reference/cel/variables.md
@@ -18,7 +18,7 @@ For the full list of fields and types on every top-level object, see the [CEL re
 
 ## Variables by policy type
 
-Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields.
+Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields. Evaluation of response body attributes or llm response info can be inconsistent when using streaming responses.
 
 | Policy | Available top-level variables |
 |--------|------------------------------|

--- a/content/docs/standalone/main/reference/cel/variables.md
+++ b/content/docs/standalone/main/reference/cel/variables.md
@@ -18,7 +18,7 @@ For the full list of fields and types on every top-level object, see the [CEL re
 
 ## Variables by policy type
 
-Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields. Evaluation of response body attributes or llm response info can be inconsistent when using streaming responses.
+Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields. Note that when using streaming responses, the evaluation of response body attributes or LLM response information can be inconsistent.
 
 | Policy | Available top-level variables |
 |--------|------------------------------|

--- a/content/docs/standalone/main/reference/cel/variables.md
+++ b/content/docs/standalone/main/reference/cel/variables.md
@@ -18,7 +18,7 @@ For the full list of fields and types on every top-level object, see the [CEL re
 
 ## Variables by policy type
 
-Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields.
+Depending on the policy, different top-level variables are bound when CEL runs. A variable is only non-null when it is populated for the current request (for example, `has(jwt.sub)` or `has(apiKey.key)`). The same name can refer to different snapshots depending on pipeline stage: early policies evaluate against the live HTTP request, while logging, tracing, and metrics run after the exchange and can include `response`, `mcp`, and full telemetry fields. Evaluation of response body attributes or llm response info can be inconsistent when using streaming responses.
 
 | Policy | Available top-level variables |
 |--------|------------------------------|


### PR DESCRIPTION
Updates to add warnings for certain cel interactions such as with transformations when response bodies are streamed back.

in service of https://github.com/agentgateway/agentgateway/pull/1750