### PR TITLE
Doc fixes

### DIFF
--- a/assets/agw-docs/pages/about/custom-resources.md
+++ b/assets/agw-docs/pages/about/custom-resources.md
@@ -22,8 +22,8 @@ To spin up a Gateway and manage its lifecycle, a gateway controller is used. The
 
 To configure routing, the {{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} provides several routing resources, such as an HTTPRoute and TCPRoute. These routes attach to a Gateway resource and define how incoming traffic is matched and forwarded to a backing destination.
 
-* [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/): The most commonly used route resource, that configures traffic routing for HTTP and HTTPS traffic. 
-* [TCPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#tcproute): A resource to route TCP requests.
+* [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/): The most commonly used route resource, that configures traffic routing for HTTP and HTTPS traffic. 
+* [TCPRoute](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute): A resource to route TCP requests.
 
 While the {{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} provides the functionality for basic request matching, redirects, rewrites, and header manipulation, it is missing more complex traffic management, resiliency, and security features, such as transformations, access logging, or route delegation. 
 

--- a/assets/agw-docs/pages/agentgateway/about/processing-order.md
+++ b/assets/agw-docs/pages/agentgateway/about/processing-order.md
@@ -61,9 +61,7 @@ PreRouting policies can only target a Gateway or ListenerSet.
 
 ### Supported PostRouting filters {#postrouting}
 
-The PostRouting phase supports only the following filters, in order of execution.
-
-By default, filters run in the PostRouting phase. If you mix pre- and post-routing filters, you might want to explicitly configure the filter to run in the PreRouting phase by settting `phase: PostRouting` on the traffic policy.
+By default, filters run in the PostRouting phase. The PostRouting phase supports only the following filters, in order of execution.
 
 PostRouting filters can target any of the supported targets for traffic policies (Gateway, HTTPRoute, GRPCRoute, or ListenerSet).
 

--- a/assets/agw-docs/pages/reference/glossary.md
+++ b/assets/agw-docs/pages/reference/glossary.md
@@ -107,12 +107,12 @@ An Envoy extension that offloads authorization decisions to an external service.
 ### Gateway
 A Gateway API resource that represents the instantiation of a gateway implementation.
 
-🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/spec/#gateway
+🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gateway
 
 ### GatewayClass
 Defines a class of Gateways with a shared configuration or implementation. Depending on how you install kgateway, you may have one or more GatewayClass resources created for you.
 
-🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/spec/#gatewayclass
+🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#gatewayclass
 
 ### Gateway Extension
 A kgateway resource that integrates extended services such as external authorization, rate limits, and processors into the Gateway data plane configuration.
@@ -127,12 +127,12 @@ Configures template, deployment, and runtime settings for a Gateway instance (in
 ### GRPCRoute
 A Gateway API resource for configuring gRPC routing rules.
 
-🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/spec/#grpcroute
+🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroute
 
 ### HTTPRoute
 A Gateway API resource for configuring HTTP/HTTPS routing rules.
 
-🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/spec/#httproute
+🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproute
 
 ### Inference Extension Project
 Mechanisms for running inference or AI processing in traffic flows—typically implemented as Envoy filters or external processors.
@@ -169,7 +169,7 @@ Controls how many requests can reach your services over time. Often implemented 
 ### ReferenceGrant
 A Gateway API resource that controls cross-namespace references.
 
-🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/spec/#referencegrant
+🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#referencegrant
 
 ### Resiliency
 Techniques like retries, timeouts, and circuit breakers that make applications more reliable when failures occur.
@@ -185,7 +185,7 @@ A network layer for service-to-service communication. Kgateway integrates with I
 ### TCPRoute
 A Gateway API resource for configuring TCP routing rules.
 
-🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/spec/#tcproute
+🔗 *See official documentation*: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute
 
 ### Traffic Management
 Features that shape, route, or modify traffic, such as load balancing, matching, filtering, and transformations.

--- a/assets/agw-docs/pages/security/cors.md
+++ b/assets/agw-docs/pages/security/cors.md
@@ -47,7 +47,7 @@ CORS policies are typically implemented to limit access to server resources for 
 
 You can configure the CORS policy at two levels:
 
-* **HTTPRoute**: For the native way in Kubernetes Gateway API, configure a CORS policy in the HTTPRoute. You can choose to apply the CORS policy to all the routes that are defined in the HTTPRoute, or to a selection of `backendRefs`. This route-level policy takes precedence over any {{< reuse "agw-docs/snippets/trafficpolicy.md" >}} CORS that you might configure. For more information, see the [Kubernetes Gateway API docs](https://gateway-api.sigs.k8s.io/reference/spec/#httpcorsfilter) and [CORS design docs](https://gateway-api.sigs.k8s.io/geps/gep-1767/).
+* **HTTPRoute**: For the native way in Kubernetes Gateway API, configure a CORS policy in the HTTPRoute. You can choose to apply the CORS policy to all the routes that are defined in the HTTPRoute, or to a selection of `backendRefs`. This route-level policy takes precedence over any {{< reuse "agw-docs/snippets/trafficpolicy.md" >}} CORS that you might configure. For more information, see the [Kubernetes Gateway API docs](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpcorsfilter) and [CORS design docs](https://gateway-api.sigs.k8s.io/geps/gep-1767/).
 * **{{< reuse "agw-docs/snippets/trafficpolicy.md" >}}**: For more flexibility to reuse the CORS policy across HTTPRoutes, specific routes, and Gateways, configure a CORS policy in the {{< reuse "agw-docs/snippets/trafficpolicy.md" >}}. You can attach an {{< reuse "agw-docs/snippets/trafficpolicy.md" >}} to a Gateway or the routes in an HTTPRoute resource.
 
 ## Before you begin

--- a/assets/agw-docs/pages/traffic-management/destination-types/kube-services/grpc-services.md
+++ b/assets/agw-docs/pages/traffic-management/destination-types/kube-services/grpc-services.md
@@ -199,7 +199,7 @@ Create an HTTPS listener so that the gateway can route gRPC traffic. GRPCRoute r
 
 ## Create a GRPCRoute {#create-grpcroute}
 
-1. Create the GRPCRoute resource. Include the `grpc.reflection.v1alpha.ServerReflection` method to enable dynamic API exploration. For detailed information about GRPCRoute fields and configuration options, see the [Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/spec/#grpcroute).
+1. Create the GRPCRoute resource. Include the `grpc.reflection.v1alpha.ServerReflection` method to enable dynamic API exploration. For detailed information about GRPCRoute fields and configuration options, see the [Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroute).
 
    ```yaml
    kubectl apply -f - <<EOF

--- a/assets/agw-docs/pages/traffic-management/grpc.md
+++ b/assets/agw-docs/pages/traffic-management/grpc.md
@@ -164,7 +164,7 @@ EOF
    EOF
    ```
 
-2. Create the GRPCRoute. The GRPCRoute includes a match for `grpc.reflection.v1alpha.ServerReflection` to enable dynamic API exploration and a match for the `Ping` method. For detailed information about GRPCRoute fields and configuration options, see the [Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/spec/#grpcroute).
+2. Create the GRPCRoute. The GRPCRoute includes a match for `grpc.reflection.v1alpha.ServerReflection` to enable dynamic API exploration and a match for the `Ping` method. For detailed information about GRPCRoute fields and configuration options, see the [Gateway API GRPCRoute documentation](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/).
 
    ```yaml {paths="grpc"}
    kubectl apply -f - <<EOF

--- a/assets/agw-docs/pages/traffic-management/header-control/request-header.md
+++ b/assets/agw-docs/pages/traffic-management/header-control/request-header.md
@@ -1,7 +1,7 @@
 
 Use the `RequestHeaderModifier` filter to add, append, overwrite, or remove request headers for a specific route. 
 
-For more information, see the [HTTPHeaderFilter specification](https://gateway-api.sigs.k8s.io/reference/spec/#httpheaderfilter).
+For more information, see the [HTTPHeaderFilter specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpheaderfilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 

--- a/assets/agw-docs/pages/traffic-management/header-control/response-header.md
+++ b/assets/agw-docs/pages/traffic-management/header-control/response-header.md
@@ -1,7 +1,7 @@
 
 Use the `ResponseHeaderModifier` filter to add, append, overwrite, or remove headers from a response before it is sent back to the client. 
 
-For more information, see the [HTTPHeaderFilter specification](https://gateway-api.sigs.k8s.io/reference/spec/#httpheaderfilter).
+For more information, see the [HTTPHeaderFilter specification](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpheaderfilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 

--- a/assets/agw-docs/pages/traffic-management/redirect/host.md
+++ b/assets/agw-docs/pages/traffic-management/redirect/host.md
@@ -1,6 +1,6 @@
 Redirect requests to a different host. 
 
-For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httprequestredirectfilter).
+For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprequestredirectfilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 

--- a/assets/agw-docs/pages/traffic-management/redirect/https.md
+++ b/assets/agw-docs/pages/traffic-management/redirect/https.md
@@ -1,6 +1,6 @@
 Redirect HTTP traffic to HTTPS. 
 
-For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httprequestredirectfilter).
+For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprequestredirectfilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 

--- a/assets/agw-docs/pages/traffic-management/redirect/path.md
+++ b/assets/agw-docs/pages/traffic-management/redirect/path.md
@@ -1,6 +1,6 @@
 Redirect requests to a different path prefix. 
 
-For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httprequestredirectfilter).
+For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprequestredirectfilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 

--- a/assets/agw-docs/pages/traffic-management/rewrite/host.md
+++ b/assets/agw-docs/pages/traffic-management/rewrite/host.md
@@ -1,6 +1,6 @@
 Replace the host header value before forwarding a request to a backend service by using the `URLRewrite` filter. 
 
-For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httpurlrewritefilter).
+For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpurlrewritefilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 

--- a/assets/agw-docs/pages/traffic-management/rewrite/path.md
+++ b/assets/agw-docs/pages/traffic-management/rewrite/path.md
@@ -1,12 +1,12 @@
 Rewrite path prefixes in requests by using the `URLRewrite` filter. 
 
-For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/spec/#httpurlrewritefilter).
+For more information, see the [{{< reuse "agw-docs/snippets/k8s-gateway-api-name.md" >}} documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httpurlrewritefilter).
 
 {{< reuse "agw-docs/snippets/agentgateway/prereq.md" >}}
 
 ## Rewrite prefix path
 
-Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmodifiertype) to rewrite path prefixes. 
+Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httppathmodifiertype) to rewrite path prefixes. 
 
 ### In-cluster services
 
@@ -255,7 +255,7 @@ EOF
 
 ## Rewrite full path
 
-Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/spec/#httppathmodifiertype) to rewrite full paths. 
+Use the [HTTPPathModifier](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httppathmodifiertype) to rewrite full paths. 
 
 ### In-cluster services
 

--- a/assets/agw-docs/pages/traffic-management/weighted-routes.md
+++ b/assets/agw-docs/pages/traffic-management/weighted-routes.md
@@ -1,4 +1,4 @@
-By default, the Kubernetes Gateway API sorts HTTPRoute rules based on their order and specificity, as defined in the [Gateway API docs](https://gateway-api.sigs.k8s.io/reference/spec/#httprouterule). When a route matches a request, no further routes are evaluated for matching, which might affect the gateway's routing decision and the policies that are applied to the traffic. With {{< reuse "/agw-docs/snippets/kgateway.md" >}}, you can configure weights for more fine-grained control over your routing rules.
+By default, the Kubernetes Gateway API sorts HTTPRoute rules based on their order and specificity, as defined in the [Gateway API docs](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule). When a route matches a request, no further routes are evaluated for matching, which might affect the gateway's routing decision and the policies that are applied to the traffic. With {{< reuse "/agw-docs/snippets/kgateway.md" >}}, you can configure weights for more fine-grained control over your routing rules.
 
 ## Before you begin
 
@@ -6,7 +6,7 @@ By default, the Kubernetes Gateway API sorts HTTPRoute rules based on their orde
 
 ## Step 1: Review the default routing behavior {#default-routing}
 
-By default, the Kubernetes Gateway API sorts HTTPRoute rules as defined in the [Gateway API docs](https://gateway-api.sigs.k8s.io/reference/spec/#httprouterule).
+By default, the Kubernetes Gateway API sorts HTTPRoute rules as defined in the [Gateway API docs](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule).
 
 1. Specificity of the route matching rule, such as a header match with largest number of matching headers.
 2. Oldest route based on creation timestamp.
@@ -215,7 +215,7 @@ By default, weighted routes are disabled. Upgrade your {{< reuse "/agw-docs/snip
 Apply an annotation at the HTTPRoute level that sets a weight for the route, which can be any 32-bit integer, including negative numbers. HTTPRoutes without the annotation are given a weight of `0`. Routes are sorted as follows:
 
 1. In descending order by weight, from highest to lowest.
-2. By [Gateway API route precedence](https://gateway-api.sigs.k8s.io/reference/spec/#httprouterule) for routes with the same weight.
+2. By [Gateway API route precedence](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule) for routes with the same weight.
 
 {{< callout type="info" >}}
 Using route delegation? Make sure to add the `kgateway.dev/route-weight` annotation to the child HTTPRoute that you want to weight. Children **do not** inherit the weight of their parent HTTPRoute.

--- a/assets/agw-docs/snippets/policies-gateway-api.md
+++ b/assets/agw-docs/snippets/policies-gateway-api.md
@@ -1,1 +1,1 @@
-Many of these policies are directly from the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/reference/spec/#httprouterule) and behave the same as those policies.
+Many of these policies are directly from the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule) and behave the same as those policies.

--- a/scripts/crd-ref-docs-config.yaml
+++ b/scripts/crd-ref-docs-config.yaml
@@ -19,16 +19,16 @@ render:
   knownTypes:
     - name: SectionName
       package: sigs.k8s.io/gateway-api/apis/v1
-      link: https://gateway-api.sigs.k8s.io/reference/spec/#sectionname
+      link: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#sectionname
     - name: BackendObjectReference
       package: sigs.k8s.io/gateway-api/apis/v1
-      link: https://gateway-api.sigs.k8s.io/reference/spec/#backendobjectreference
+      link: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#backendobjectreference
     - name: LocalPolicyTargetReferenceWithSectionName
       package: sigs.k8s.io/gateway-api/apis/v1alpha2
-      link: https://gateway-api.sigs.k8s.io/reference/spec/#localpolicytargetreferencewithsectionname
+      link: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#localpolicytargetreferencewithsectionname
     - name: LocalPolicyTargetSelectorWithSectionName
       package: sigs.k8s.io/gateway-api/apis/v1alpha2
-      link: https://gateway-api.sigs.k8s.io/reference/spec/#localpolicytargetselectorwithsectionname
+      link: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#localpolicytargetselectorwithsectionname
     # Kubernetes core/meta types whose generated anchors don't exist on the
     # k8s API reference page.
     - name: PullPolicy


### PR DESCRIPTION
- wording
- Kubernetes Gateway API ref docs link changed to https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/