### PR TITLE
Doc fixes

### DIFF
--- a/assets/agw-docs/pages/agentgateway/llm/about.md
+++ b/assets/agw-docs/pages/agentgateway/llm/about.md
@@ -24,9 +24,8 @@ When adopting an LLM on an enterprise-level, you typically run into the followin
 
 ## Supported providers
 
+{{< reuse "agw-docs/snippets/llm-comparison.md" >}}
+
 {{< callout type="info" >}}
 Don't see your provider? You might still be able to use it with agentgateway! Many LLM providers offer OpenAI-compatible APIs. To get started, follow the [OpenAI compatible]({{< link-hextra path="/llm/providers/openai-compatible/" >}}) docs.
 {{< /callout >}}
-
-{{< reuse "agw-docs/snippets/llm-comparison.md" >}}
-

--- a/assets/agw-docs/pages/agentgateway/llm/providers/anthropic.md
+++ b/assets/agw-docs/pages/agentgateway/llm/providers/anthropic.md
@@ -601,6 +601,148 @@ Example output:
 {{% /tab %}}
 {{< /tabs >}}
 
+## Use Claude Platform on AWS
+
+[Claude Platform on AWS](https://docs.aws.amazon.com/claude-platform/latest/userguide/welcome.html) hosts Anthropic's native Messages API on AWS infrastructure at `aws-external-anthropic.{region}.api.aws`. Because the API is the same Anthropic Messages API, you point the `anthropic` provider at the AWS endpoint and choose either API-key or AWS SigV4 authentication.
+
+<!--TODO 1.3 release -->
+{{< callout type="info" >}}
+Before you begin, [install agentgateway with the nightly build]({{< link-hextra path="/quickstart/install/">}}).
+{{< /callout >}}
+
+{{< tabs tabTotal="2" items="API key, AWS SigV4" >}}
+{{% tab tabName="API key" %}}
+
+1. Create a Kubernetes secret that contains your Anthropic-on-AWS API key.
+
+   ```sh
+   export ANTHROPIC_AWS_API_KEY=<insert your API key>
+   ```
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: anthropic-aws-secret
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   type: Opaque
+   stringData:
+     Authorization: $ANTHROPIC_AWS_API_KEY
+   EOF
+   ```
+
+2. Create a {{< reuse "agw-docs/snippets/backend.md" >}} that points the `anthropic` provider at the Claude Platform endpoint and references the API key secret.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: agentgateway.dev/v1alpha1
+   kind: {{< reuse "agw-docs/snippets/backend.md" >}}
+   metadata:
+     name: anthropic-aws
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     ai:
+       provider:
+         anthropic: {}
+         host: aws-external-anthropic.us-west-2.api.aws
+         port: 443
+         pathPrefix: /v1
+     policies:
+       auth:
+         secretRef:
+           name: anthropic-aws-secret
+   EOF
+   ```
+
+   | Setting | Description |
+   |---------|-------------|
+   | `provider.anthropic` | Marks the provider as Anthropic. No model override is required, so the field is left empty. |
+   | `provider.host` | The Claude Platform endpoint hostname. Use the form `aws-external-anthropic.{region}.api.aws`. |
+   | `provider.port` | The HTTPS port for Claude Platform, set to `443`. |
+   | `provider.pathPrefix` | The Anthropic API path prefix on Claude Platform, set to `/v1`. |
+   | `policies.auth.secretRef` | References the secret that holds the API key. The token is automatically sent in the `x-api-key` header. |
+
+{{% /tab %}}
+{{% tab tabName="AWS SigV4" %}}
+
+1. Make sure the agentgateway proxy pod has access to AWS credentials, for example through [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or a Kubernetes secret with `accessKey`, `secretKey`, and optional `sessionToken`. For the secret-based approach:
+
+   ```yaml
+   kubectl create secret generic anthropic-aws-creds \
+     -n {{< reuse "agw-docs/snippets/namespace.md" >}} \
+     --from-literal=accessKey="$AWS_ACCESS_KEY_ID" \
+     --from-literal=secretKey="$AWS_SECRET_ACCESS_KEY" \
+     --from-literal=sessionToken="$AWS_SESSION_TOKEN" \
+     --type=Opaque \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+2. Create a {{< reuse "agw-docs/snippets/backend.md" >}} that points the `anthropic` provider at the Claude Platform endpoint and uses AWS SigV4 authentication with the `aws-external-anthropic` service name.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: agentgateway.dev/v1alpha1
+   kind: {{< reuse "agw-docs/snippets/backend.md" >}}
+   metadata:
+     name: anthropic-aws
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     ai:
+       provider:
+         anthropic: {}
+         host: aws-external-anthropic.us-west-2.api.aws
+         port: 443
+         pathPrefix: /v1
+     policies:
+       auth:
+         aws:
+           serviceName: aws-external-anthropic
+           secretRef:
+             name: anthropic-aws-creds
+   EOF
+   ```
+
+   | Setting | Description |
+   |---------|-------------|
+   | `provider.anthropic` | Marks the provider as Anthropic. No model override is required, so the field is left empty. |
+   | `provider.host` | The Claude Platform endpoint hostname. Use the form `aws-external-anthropic.{region}.api.aws`. |
+   | `provider.port` | The HTTPS port for Claude Platform, set to `443`. |
+   | `provider.pathPrefix` | The Anthropic API path prefix on Claude Platform, set to `/v1`. |
+   | `policies.auth.aws.serviceName` | The SigV4 service name. Claude Platform requires `aws-external-anthropic`. |
+   | `policies.auth.aws.secretRef` | References the secret with AWS credentials. To use implicit credentials from the workload environment (for example IRSA), omit `secretRef`. |
+
+{{% /tab %}}
+{{< /tabs >}}
+
+3. Create an HTTPRoute that routes traffic to the {{< reuse "agw-docs/snippets/backend.md" >}}. The example also injects the `anthropic-workspace-id` header that Claude Platform requires. Replace `wrkspc_XXXXX` with your Anthropic workspace ID.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: HTTPRoute
+   metadata:
+     name: anthropic-aws
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     parentRefs:
+       - name: agentgateway-proxy
+         namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+     rules:
+     - filters:
+       - type: RequestHeaderModifier
+         requestHeaderModifier:
+           set:
+           - name: anthropic-workspace-id
+             value: wrkspc_XXXXX
+       backendRefs:
+       - name: anthropic-aws
+         namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+         group: agentgateway.dev
+         kind: {{< reuse "agw-docs/snippets/backend.md" >}}
+   EOF
+   ```
+
 ## Connect to Claude Code
 
 {{% conditional-text include-if="kubernetes,standalone" %}}To route Claude Code CLI traffic through agentgateway, see the [Claude Code integration guide]({{< link-hextra path="/integrations/llm-clients/claude-code" >}}).{{% /conditional-text %}}{{% conditional-text include-if="kubernetes" %}} For a full tutorial with prompt guards and observability, see the [Claude Code CLI proxy tutorial]({{< link-hextra path="/tutorials/claude-code-proxy" >}}).{{% /conditional-text %}}

--- a/assets/agw-docs/pages/agentgateway/llm/providers/bedrock.md
+++ b/assets/agw-docs/pages/agentgateway/llm/providers/bedrock.md
@@ -1,5 +1,9 @@
 Configure [Amazon Bedrock](https://aws.amazon.com/bedrock/) as an LLM provider in agentgateway.
 
+{{< callout type="info" >}}
+Agentgateway accepts OpenAI-formatted requests (such as the `/v1/chat/completions` request body shape) and returns OpenAI-formatted responses, regardless of the route path that you configure. Agentgateway translates between OpenAI and Bedrock formats internally. Bedrock-native APIs such as the [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html) request and response shapes are not supported. Usage fields in responses follow the OpenAI shape (`prompt_tokens`, `completion_tokens`, `total_tokens`), not the Bedrock shape (`inputTokens`, `outputTokens`, `totalTokens`).
+{{< /callout >}}
+
 ## Before you begin
 
 1. Set up an [agentgateway proxy]({{< link-hextra path="/setup/gateway/" >}}). 
@@ -85,30 +89,9 @@ Configure [Amazon Bedrock](https://aws.amazon.com/bedrock/) as an LLM provider i
    | `bedrock.region`    | The AWS region where your Bedrock model is deployed. Multiple regions are not supported. |
    | `policies.auth` | Provide the credentials to use to access the Amazon Bedrock API. The example refers to the secret that you previously created. To use implicit credentials from the workload or environment instead (for example IRSA{{< version exclude-if="1.1.x" >}} and AWS IAM Identity Center (SSO) profiles{{< /version >}}), omit the `auth` settings. |
 
-3. Create an HTTPRoute resource to route requests through your agentgateway proxy to the Bedrock {{< reuse "agw-docs/snippets/backend.md" >}}. The following example sets up a route. Note that {{< reuse "agw-docs/snippets/kgateway.md" >}} automatically rewrites the endpoint to the appropriate chat completion endpoint of the LLM provider for you, based on the LLM provider that you set up in the {{< reuse "agw-docs/snippets/backend.md" >}} resource. The default Bedrock route is `/model/${MODEL}/converse`, such as `/model/amazon.nova-micro-v1:0/converse`.
+3. Create an HTTPRoute resource to route requests through your agentgateway proxy to the Bedrock {{< reuse "agw-docs/snippets/backend.md" >}}.
 
-   {{< tabs tabTotal="3" items="Bedrock default, OpenAI-compatible v1/chat/completions, Custom route" >}}
-   {{% tab tabName="Bedrock default" %}}
-   ```yaml
-   kubectl apply -f- <<EOF
-   apiVersion: gateway.networking.k8s.io/v1
-   kind: HTTPRoute
-   metadata:
-     name: bedrock
-     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
-   spec:
-     parentRefs:
-       - name: agentgateway-proxy
-         namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
-     rules:
-     - backendRefs:
-       - name: bedrock
-         namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
-         group: agentgateway.dev
-         kind: {{< reuse "agw-docs/snippets/backend.md" >}}
-   EOF
-   ```
-   {{% /tab %}}
+   {{< tabs tabTotal="2" items="OpenAI-compatible v1/chat/completions, Custom route" >}}
    {{% tab tabName="OpenAI-compatible v1/chat/completions" %}}
    ```yaml
    kubectl apply -f- <<EOF
@@ -162,36 +145,9 @@ Configure [Amazon Bedrock](https://aws.amazon.com/bedrock/) as an LLM provider i
    {{< /tabs >}}
 
 
-4. Send a request to the LLM provider API along the route that you previously created, such as `/bedrock` or `/v1/chat/completions` depending on your route configuration. Verify that the request succeeds and that you get back a response from the chat completion API.
+4. Send a request to the LLM provider API along the route that you previously created, such as `/bedrock` or `/v1/chat/completions` depending on your route configuration. The request body must be in OpenAI chat-completions format. Verify that the request succeeds and that you get back a response from the chat completion API.
 
-   {{< tabs tabTotal="3" items="Bedrock default, OpenAI-compatible v1/chat/completions, Custom route" >}}
-   {{% tab tabName="Bedrock default" %}}
-   **Cloud Provider LoadBalancer**:
-   ```sh
-   curl "$INGRESS_GW_ADDRESS/model/amazon.nova-micro-v1:0/converse" -H content-type:application/json -d '{
-       "model": "",
-       "messages": [
-         {
-           "role": "user",
-           "content": "You are a cloud native solutions architect, skilled in explaining complex technical concepts such as API Gateway, microservices, LLM operations, kubernetes, and advanced networking patterns. Write me a 20-word pitch on why I should use an AI gateway in my Kubernetes cluster."
-         }
-       ]
-     }' | jq
-   ```
-
-   **Localhost**:
-   ```sh
-   curl "localhost:8080/model/amazon.nova-micro-v1:0/converse" -H content-type:application/json -d '{
-       "model": "",
-       "messages": [
-         {
-           "role": "user",
-           "content": "You are a cloud native solutions architect, skilled in explaining complex technical concepts such as API Gateway, microservices, LLM operations, kubernetes, and advanced networking patterns. Write me a 20-word pitch on why I should use an AI gateway in my Kubernetes cluster."
-         }
-       ]
-     }' | jq
-   ```
-   {{% /tab %}}
+   {{< tabs tabTotal="2" items="OpenAI-compatible v1/chat/completions, Custom route" >}}
    {{% tab tabName="OpenAI-compatible v1/chat/completions" %}}
    **Cloud Provider LoadBalancer**:
    ```sh
@@ -248,27 +204,27 @@ Configure [Amazon Bedrock](https://aws.amazon.com/bedrock/) as an LLM provider i
    {{% /tab %}}
    {{< /tabs >}}
    
-   Example output: 
+   Example output. Note that agentgateway returns OpenAI-shaped responses, including OpenAI-style usage fields (`prompt_tokens`, `completion_tokens`, `total_tokens`), even though the upstream provider is Bedrock.
    ```json
    {
-     "metrics": {
-       "latencyMs": 2097
-     },
-     "output": {
-       "message": {
-         "content": [
-           {
-             "text": "\nAn AI gateway in your Kubernetes cluster can enhance performance, scalability, and security while simplifying complex operations. It provides a centralized entry point for AI workloads, automates deployment and management, and ensures high availability."
-           }
-         ],
-         "role": "assistant"
+     "id": "chatcmpl-abc123",
+     "object": "chat.completion",
+     "created": 1730000000,
+     "model": "amazon.nova-micro-v1:0",
+     "choices": [
+       {
+         "index": 0,
+         "message": {
+           "role": "assistant",
+           "content": "An AI gateway in your Kubernetes cluster can enhance performance, scalability, and security while simplifying complex operations. It provides a centralized entry point for AI workloads, automates deployment and management, and ensures high availability."
+         },
+         "finish_reason": "stop"
        }
-     },
-     "stopReason": "end_turn",
+     ],
      "usage": {
-       "inputTokens": 60,
-       "outputTokens": 47,
-       "totalTokens": 107
+       "prompt_tokens": 60,
+       "completion_tokens": 47,
+       "total_tokens": 107
      }
    }
    ```
@@ -355,49 +311,9 @@ Prompt caching is supported for Bedrock Claude 3+ and Nova models.
 
 ## Extended thinking and reasoning
 
-Extended thinking and reasoning lets models reason through complex problems before generating a response. You can opt in to extended thinking and reasoning by adding specific parameters to your request. Agentgateway maps these parameters to Bedrock's native format automatically.
+Extended thinking and reasoning lets models reason through complex problems before generating a response. You can opt in to extended thinking and reasoning by adding the OpenAI `reasoning_effort` field to your request. Agentgateway translates this to Bedrock's native thinking budget automatically.
 
 **Note**: Extended thinking and reasoning requires a Claude model that supports it, such as `us.anthropic.claude-opus-4-20250514-v1:0`.
-
-{{< tabs tabTotal="2" items="Bedrock default, OpenAI-compatible v1/chat/completions" >}}
-{{% tab tabName="Bedrock default" %}}
-
-Use the `reasoning.effort` field to control how much reasoning the model applies. The value is automatically mapped to a thinking budget.
-
-| `reasoning.effort` value | Thinking budget |
-|---|---|
-| `minimal` or `low` | 1,024 tokens |
-| `medium` | 2,048 tokens |
-| `high` or `xhigh` | 4,096 tokens |
-
-**Cloud Provider LoadBalancer**:
-```sh
-curl "$INGRESS_GW_ADDRESS/model/us.anthropic.claude-opus-4-20250514-v1:0/converse" \
-  -H content-type:application/json -d '{
-  "model": "",
-  "max_output_tokens": 5000,
-  "input": "Explain the trade-offs between consistency and availability in distributed systems.",
-  "reasoning": {
-    "effort": "high"
-  }
-}' | jq
-```
-
-**Localhost**:
-```sh
-curl "localhost:8080/model/us.anthropic.claude-opus-4-20250514-v1:0/converse" \
-  -H content-type:application/json -d '{
-  "model": "",
-  "max_output_tokens": 5000,
-  "input": "Explain the trade-offs between consistency and availability in distributed systems.",
-  "reasoning": {
-    "effort": "high"
-  }
-}' | jq
-```
-
-{{% /tab %}}
-{{% tab tabName="OpenAI-compatible v1/chat/completions" %}}
 
 Use the `reasoning_effort` field to control how much reasoning the model applies. The value is automatically mapped to a thinking budget.
 
@@ -437,77 +353,9 @@ curl "localhost:8080/v1/chat/completions" -H content-type:application/json -d '{
 }' | jq
 ```
 
-{{% /tab %}}
-
-{{< /tabs >}}
-
 ## Structured outputs
 
-Structured outputs constrain the model to respond with a specific JSON schema. You must provide the schema definition in your request. 
-
-{{< tabs tabTotal="2" items="Bedrock default, OpenAI-compatible v1/chat/completions" >}}
-{{% tab tabName="Bedrock default" %}}
-
-Provide the JSON schema definition in the `text.format` field.
-
-**Cloud Provider LoadBalancer**:
-```sh
-curl "$INGRESS_GW_ADDRESS/model/us.anthropic.claude-opus-4-20250514-v1:0/converse" \
-  -H content-type:application/json -d '{
-  "model": "",
-  "max_output_tokens": 256,
-  "input": "Is the sky blue? Respond with your answer and a confidence score between 0 and 1.",
-  "text": {
-    "format": {
-      "type": "json_schema",
-      "json_schema": {
-        "name": "answer_schema",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "answer": { "type": "string" },
-            "confidence": { "type": "number" }
-          },
-          "required": ["answer", "confidence"],
-          "additionalProperties": false
-        }
-      }
-    }
-  }
-}' | jq
-```
-
-**Localhost**:
-```sh
-curl "localhost:8080/model/us.anthropic.claude-opus-4-20250514-v1:0/converse" \
-  -H content-type:application/json -d '{
-  "model": "",
-  "max_output_tokens": 256,
-  "input": "Is the sky blue? Respond with your answer and a confidence score between 0 and 1.",
-  "text": {
-    "format": {
-      "type": "json_schema",
-      "json_schema": {
-        "name": "answer_schema",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "answer": { "type": "string" },
-            "confidence": { "type": "number" }
-          },
-          "required": ["answer", "confidence"],
-          "additionalProperties": false
-        }
-      }
-    }
-  }
-}' | jq
-```
-
-{{% /tab %}}
-{{% tab tabName="OpenAI-compatible v1/chat/completions" %}}
-
-Provide the schema definition in the `response_format` field. Agentgateway translates this to Bedrock's native format automatically.
+Structured outputs constrain the model to respond with a specific JSON schema. Provide the schema definition in the OpenAI `response_format` field of your request. Agentgateway translates this to Bedrock's native format automatically.
 
 **Cloud Provider LoadBalancer**:
 ```sh
@@ -566,10 +414,5 @@ curl "localhost:8080/v1/chat/completions" -H content-type:application/json -d '{
   ]
 }' | jq
 ```
-
-
-{{% /tab %}}
-
-{{< /tabs >}}
 
 {{< reuse "agw-docs/snippets/agentgateway/llm-next.md" >}}

--- a/assets/agw-docs/versions/n-patch.md
+++ b/assets/agw-docs/versions/n-patch.md
@@ -1,1 +1,1 @@
-{{< version include-if="1.1.x" >}}1.1.0{{< /version >}}{{< version include-if="1.2.x" >}}1.2.0{{< /version >}}{{< version include-if="1.3.x" >}}1.2.0{{< /version >}}
+{{< version include-if="1.1.x" >}}1.1.0{{< /version >}}{{< version include-if="1.2.x" >}}1.2.1{{< /version >}}{{< version include-if="1.3.x" >}}1.2.1{{< /version >}}

--- a/assets/agw-docs/versions/patch_n+1.md
+++ b/assets/agw-docs/versions/patch_n+1.md
@@ -1,1 +1,1 @@
-{{< version include-if="1.1.x" >}}1.2.0{{< /version >}}{{< version include-if="1.2.x" >}}1.2.0{{< /version >}}{{< version include-if="1.3.x" >}}1.2.0{{< /version >}}
+{{< version include-if="1.1.x" >}}1.2.1{{< /version >}}{{< version include-if="1.2.x" >}}1.2.1{{< /version >}}{{< version include-if="1.3.x" >}}1.2.1{{< /version >}}

--- a/assets/agw-docs/versions/patch_n-1.md
+++ b/assets/agw-docs/versions/patch_n-1.md
@@ -1,1 +1,1 @@
-{{< version include-if="1.1.x" >}}1.0.1{{< /version >}}{{< version include-if="1.2.x" >}}1.1.0{{< /version >}}{{< version include-if="1.3.x" >}}1.2.0{{< /version >}}
+{{< version include-if="1.1.x" >}}1.0.1{{< /version >}}{{< version include-if="1.2.x" >}}1.1.0{{< /version >}}{{< version include-if="1.3.x" >}}1.2.1{{< /version >}}

--- a/content/docs/standalone/latest/llm/about.md
+++ b/content/docs/standalone/latest/llm/about.md
@@ -13,17 +13,11 @@ Agentgateway provides seamless integration with various Large Language Model (LL
 
 ## Supported providers
 
-Agentgateway supports three categories of LLM providers:
+Agentgateway supports native, OpenAI-compatible, and self-hosted LLM providers.
 
 ### Native providers
 
-These providers have first-class support with dedicated configuration:
-- [OpenAI]({{< link-hextra path="/llm/providers/openai/" >}})
-- [Anthropic]({{< link-hextra path="/llm/providers/anthropic/" >}})
-- [Google Gemini]({{< link-hextra path="/llm/providers/gemini/" >}})
-- [Google Vertex AI]({{< link-hextra path="/llm/providers/vertex/" >}})
-- [Amazon Bedrock]({{< link-hextra path="/llm/providers/bedrock/" >}})
-- [Azure]({{< link-hextra path="/llm/providers/azure/" >}})
+{{< reuse "agw-docs/snippets/llm-comparison.md" >}}
 
 ### OpenAI-compatible providers
 
@@ -43,12 +37,6 @@ Run models locally or in your own infrastructure:
 - [Ollama]({{< link-hextra path="/llm/providers/ollama/" >}})
 - [vLLM]({{< link-hextra path="/llm/providers/openai-compatible/#vllm" >}})
 - [LM Studio]({{< link-hextra path="/llm/providers/openai-compatible/#lm-studio" >}})
-
-{{< callout type="info" >}}
-Don't see your provider? You might still be able to use it with agentgateway! Many LLM providers offer OpenAI-compatible APIs. To get started, follow the [OpenAI compatible]({{< link-hextra path="/llm/providers/openai-compatible/" >}}) docs.
-{{< /callout >}}
-
-{{< reuse "agw-docs/snippets/llm-comparison.md" >}}
 
 ## Using the API
 

--- a/content/docs/standalone/latest/llm/providers/bedrock.md
+++ b/content/docs/standalone/latest/llm/providers/bedrock.md
@@ -6,6 +6,10 @@ description: Configuration and setup for Amazon Bedrock provider
 
 Configure Amazon Bedrock as an LLM provider in agentgateway.
 
+{{< callout type="info" >}}
+Agentgateway accepts only OpenAI-formatted requests (such as the `/v1/chat/completions` request body shape) and returns OpenAI-formatted responses, regardless of the route path that you configure. Agentgateway translates between OpenAI and Bedrock formats internally. Bedrock's native [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html) request and response shapes are not supported. Usage fields in responses follow the OpenAI shape (`prompt_tokens`, `completion_tokens`, `total_tokens`), not the Bedrock shape (`inputTokens`, `outputTokens`, `totalTokens`).
+{{< /callout >}}
+
 ## Authentication
 
 Before you can use Bedrock as an LLM provider, you must authenticate by using the standard [AWS authentication sources](https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html).
@@ -90,43 +94,7 @@ curl "localhost:3000/v1/chat/completions" -H content-type:application/json -d '{
 
 ## Structured outputs
 
-Structured outputs constrain the model to respond with a specific JSON schema. You must provide the schema definition in your request.
-
-{{< tabs tabTotal="2" items="Bedrock default, OpenAI-compatible v1/chat/completions" >}}
-{{% tab tabName="Bedrock default" %}}
-
-Provide the JSON schema definition in the `text.format` field.
-
-```sh
-curl "localhost:3000/model/us.anthropic.claude-opus-4-20250514-v1:0/converse" \
-  -H content-type:application/json -d '{
-  "model": "",
-  "max_output_tokens": 256,
-  "input": "Is the sky blue? Respond with your answer and a confidence score between 0 and 1.",
-  "text": {
-    "format": {
-      "type": "json_schema",
-      "json_schema": {
-        "name": "answer_schema",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "answer": { "type": "string" },
-            "confidence": { "type": "number" }
-          },
-          "required": ["answer", "confidence"],
-          "additionalProperties": false
-        }
-      }
-    }
-  }
-}' | jq
-```
-
-{{% /tab %}}
-{{% tab tabName="OpenAI-compatible v1/chat/completions" %}}
-
-Provide the schema definition in the `response_format` field. Agentgateway translates this to Bedrock's native format automatically.
+Structured outputs constrain the model to respond with a specific JSON schema. Provide the schema definition in the OpenAI `response_format` field of your request. Agentgateway translates this to Bedrock's native format automatically.
 
 ```sh
 curl "localhost:3000/v1/chat/completions" -H content-type:application/json -d '{
@@ -155,7 +123,3 @@ curl "localhost:3000/v1/chat/completions" -H content-type:application/json -d '{
   ]
 }' | jq
 ```
-
-{{% /tab %}}
-
-{{< /tabs >}}

--- a/content/docs/standalone/main/llm/about.md
+++ b/content/docs/standalone/main/llm/about.md
@@ -13,17 +13,11 @@ Agentgateway provides seamless integration with various Large Language Model (LL
 
 ## Supported providers
 
-Agentgateway supports three categories of LLM providers:
+Agentgateway supports native, OpenAI-compatible, and self-hosted LLM providers.
 
 ### Native providers
 
-These providers have first-class support with dedicated configuration:
-- [OpenAI]({{< link-hextra path="/llm/providers/openai/" >}})
-- [Anthropic]({{< link-hextra path="/llm/providers/anthropic/" >}})
-- [Google Gemini]({{< link-hextra path="/llm/providers/gemini/" >}})
-- [Google Vertex AI]({{< link-hextra path="/llm/providers/vertex/" >}})
-- [Amazon Bedrock]({{< link-hextra path="/llm/providers/bedrock/" >}})
-- [Azure]({{< link-hextra path="/llm/providers/azure/" >}})
+{{< reuse "agw-docs/snippets/llm-comparison.md" >}}
 
 ### OpenAI-compatible providers
 
@@ -43,12 +37,6 @@ Run models locally or in your own infrastructure:
 - [Ollama]({{< link-hextra path="/llm/providers/ollama/" >}})
 - [vLLM]({{< link-hextra path="/llm/providers/openai-compatible/#vllm" >}})
 - [LM Studio]({{< link-hextra path="/llm/providers/openai-compatible/#lm-studio" >}})
-
-{{< callout type="info" >}}
-Don't see your provider? You might still be able to use it with agentgateway! Many LLM providers offer OpenAI-compatible APIs. To get started, follow the [OpenAI compatible]({{< link-hextra path="/llm/providers/openai-compatible/" >}}) docs.
-{{< /callout >}}
-
-{{< reuse "agw-docs/snippets/llm-comparison.md" >}}
 
 ## Using the API
 

--- a/content/docs/standalone/main/llm/providers/anthropic.md
+++ b/content/docs/standalone/main/llm/providers/anthropic.md
@@ -228,6 +228,80 @@ Example output:
 ```
 
 
+## Use Claude Platform on AWS
+
+[Claude Platform on AWS](https://docs.aws.amazon.com/claude-platform/latest/userguide/welcome.html) hosts Anthropic's native Messages API on AWS infrastructure at `aws-external-anthropic.{region}.api.aws`. Because the API is the same Anthropic Messages API, you point the `anthropic` provider at the AWS endpoint and choose either API-key or AWS SigV4 authentication.
+
+<!--TODO 1.3 release -->
+{{< callout type="info" >}}
+Before you begin, [install agentgateway with the nightly build]({{< link-hextra path="/quickstart/install/">}}).
+{{< /callout >}}
+
+{{< tabs tabTotal="2" items="API key, AWS SigV4" >}}
+{{% tab tabName="API key" %}}
+
+Store your Anthropic-on-AWS API key in a file and reference it from the provider configuration. Override the upstream host to point at the Claude Platform endpoint.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+
+llm:
+  models:
+  - name: "*"
+    provider: anthropic
+    requestHeaders:
+      set:
+        anthropic-workspace-id: wrkspc_XXXXX
+    params:
+      awsRegion: us-west-2
+      hostOverride: aws-external-anthropic.us-west-2.api.aws:443
+      pathPrefix: /v1
+      apiKey:
+        file: $HOME/.secrets/anthropic-aws
+    backendTLS: {}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `requestHeaders.set.anthropic-workspace-id` | The Anthropic workspace ID that scopes the request. Replace `wrkspc_XXXXX` with your workspace ID. |
+| `params.hostOverride` | The Claude Platform endpoint host and port. Use the form `aws-external-anthropic.{region}.api.aws:443`. |
+| `params.pathPrefix` | The Anthropic API path prefix on Claude Platform, set to `/v1`. |
+| `params.apiKey.file` | A path to a file that contains the API key. |
+| `backendTLS: {}` | Enables TLS to the upstream host. Required because Claude Platform is served over HTTPS. |
+
+{{% /tab %}}
+{{% tab tabName="AWS SigV4" %}}
+
+Use IAM credentials from the environment (for example IRSA, an EC2 instance profile, or an AWS SSO profile) and let agentgateway sign requests with SigV4. Set `auth.aws.serviceName` to `aws-external-anthropic`, which is the SigV4 service name that Claude Platform expects.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+
+llm:
+  models:
+  - name: "claude-platform/*"
+    provider: anthropic
+    requestHeaders:
+      set:
+        anthropic-workspace-id: wrkspc_XXXXX
+    params:
+      awsRegion: us-west-2
+      baseUrl: https://aws-external-anthropic.us-west-2.api.aws/v1
+    auth:
+      aws:
+        serviceName: aws-external-anthropic
+```
+
+| Setting | Description |
+|---------|-------------|
+| `name` | Matches model names that start with `claude-platform/`, so you can route Claude Platform traffic alongside other Anthropic models. |
+| `requestHeaders.set.anthropic-workspace-id` | The Anthropic workspace ID that scopes the request. Replace `wrkspc_XXXXX` with your workspace ID. |
+| `params.baseUrl` | The full Claude Platform base URL, including scheme and `/v1` path prefix. |
+| `auth.aws.serviceName` | The SigV4 service name. Claude Platform requires `aws-external-anthropic`. Implicit AWS credentials from the workload environment are used to sign each request. |
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Connect to Claude Code
 
 To route Claude Code CLI traffic through agentgateway, see the [Claude Code integration guide]({{< link-hextra path="/integrations/llm-clients/claude-code" >}}).

--- a/content/docs/standalone/main/llm/providers/bedrock.md
+++ b/content/docs/standalone/main/llm/providers/bedrock.md
@@ -6,6 +6,10 @@ description: Configuration and setup for Amazon Bedrock provider
 
 Configure Amazon Bedrock as an LLM provider in agentgateway.
 
+{{< callout type="info" >}}
+Agentgateway accepts only OpenAI-formatted requests (such as the `/v1/chat/completions` request body shape) and returns OpenAI-formatted responses, regardless of the route path that you configure. Agentgateway translates between OpenAI and Bedrock formats internally. Bedrock's native [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html) request and response shapes are not supported. Usage fields in responses follow the OpenAI shape (`prompt_tokens`, `completion_tokens`, `total_tokens`), not the Bedrock shape (`inputTokens`, `outputTokens`, `totalTokens`).
+{{< /callout >}}
+
 ## Authentication
 
 Before you can use Bedrock as an LLM provider, you must authenticate by using the standard [AWS authentication sources](https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html).
@@ -90,43 +94,7 @@ curl "localhost:3000/v1/chat/completions" -H content-type:application/json -d '{
 
 ## Structured outputs
 
-Structured outputs constrain the model to respond with a specific JSON schema. You must provide the schema definition in your request.
-
-{{< tabs tabTotal="2" items="Bedrock default, OpenAI-compatible v1/chat/completions" >}}
-{{% tab tabName="Bedrock default" %}}
-
-Provide the JSON schema definition in the `text.format` field.
-
-```sh
-curl "localhost:3000/model/us.anthropic.claude-opus-4-20250514-v1:0/converse" \
-  -H content-type:application/json -d '{
-  "model": "",
-  "max_output_tokens": 256,
-  "input": "Is the sky blue? Respond with your answer and a confidence score between 0 and 1.",
-  "text": {
-    "format": {
-      "type": "json_schema",
-      "json_schema": {
-        "name": "answer_schema",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "answer": { "type": "string" },
-            "confidence": { "type": "number" }
-          },
-          "required": ["answer", "confidence"],
-          "additionalProperties": false
-        }
-      }
-    }
-  }
-}' | jq
-```
-
-{{% /tab %}}
-{{% tab tabName="OpenAI-compatible v1/chat/completions" %}}
-
-Provide the schema definition in the `response_format` field. Agentgateway translates this to Bedrock's native format automatically.
+Structured outputs constrain the model to respond with a specific JSON schema. Provide the schema definition in the OpenAI `response_format` field of your request. Agentgateway translates this to Bedrock's native format automatically.
 
 ```sh
 curl "localhost:3000/v1/chat/completions" -H content-type:application/json -d '{
@@ -155,7 +123,3 @@ curl "localhost:3000/v1/chat/completions" -H content-type:application/json -d '{
   ]
 }' | jq
 ```
-
-{{% /tab %}}
-
-{{< /tabs >}}

--- a/layouts/partials/homepage-content.html
+++ b/layouts/partials/homepage-content.html
@@ -1417,5 +1417,5 @@ function hpScrollToFeat(key) {
     if (diagram) diagram.classList.add('pulse-off');
     return;
   }
-
+})();
 </script>


### PR DESCRIPTION
- Supported LLM providers table revise note and placement so it gets an h3
- index missing closing tag that causes [build](https://dash.cloudflare.com/0653eeaee9bffe11be6693c01ef6e885/pages/view/agentproxy/4f833f2f-a979-4647-8402-00c91ce3ff68) to break
- remove Bedrock-style API, supports the OpenAI-style
- Claude on AWS
- bump version