### PR TITLE
Fixed test failure for DFP

### DIFF
--- a/assets/agw-docs/pages/traffic-management/dfp.md
+++ b/assets/agw-docs/pages/traffic-management/dfp.md
@@ -92,7 +92,7 @@ YAMLTest -f - <<'EOF'
 EOF
 {{< /doc-test >}}
 
-3. Send a request to a hostname of your choice, such as `httpbin.org`. The Dynamic Forward Proxy resolves the host at request time and forwards the request to it, so the host's welcome page is returned. Because no upstream hosts are pre-defined in the Backend, you can send a request to any reachable host without changing the configuration.
+3. Send a request to a hostname of your choice, such as `httpbin.org`. The Dynamic Forward Proxy resolves the host at request time and forwards the request to it, so the host's welcome page is returned. Because no upstream hosts are pre-defined in the Backend, you can send a request to any reachable host without changing the configuration. For example, for quick testing, you might send a request with the host header set to an in-cluster service, such as httpbin.httpbin.svc.cluster.local:8000.
    {{< tabs tabTotal="2" items="Cloud Provider LoadBalancer,Port forward for local testing" >}}
    {{% tab tabName="Cloud Provider LoadBalancer" %}}
    ```sh

--- a/assets/agw-docs/pages/traffic-management/dfp.md
+++ b/assets/agw-docs/pages/traffic-management/dfp.md
@@ -111,10 +111,7 @@ EOF
    {{% /tab %}}
    {{< /tabs >}}
 
-   {{< callout type="info" >}}
-   The Dynamic Forward Proxy resolves any reachable host, including in-cluster services. To verify the proxy without depending on an external site, send a request with the host header set to an in-cluster service, such as `httpbin.httpbin.svc.cluster.local:8000`.
-   {{< /callout >}}
-   
+  
    Example output: 
    ```console
    * Request completely sent off

--- a/assets/agw-docs/pages/traffic-management/dfp.md
+++ b/assets/agw-docs/pages/traffic-management/dfp.md
@@ -92,7 +92,7 @@ YAMLTest -f - <<'EOF'
 EOF
 {{< /doc-test >}}
 
-3. Send a request to a hostname of your choice, such as `httpbin.org`. The Dynamic Forward Proxy resolves the host at request time and forwards the request to it, so the host's welcome page is returned. Because no upstream hosts are pre-defined in the Backend, you can send a request to any reachable host without changing the configuration. For example, for quick testing, you might send a request with the host header set to an in-cluster service, such as httpbin.httpbin.svc.cluster.local:8000.
+3. Send a request to a hostname of your choice, such as `httpbin.org`. The Dynamic Forward Proxy resolves the host at request time and forwards the request to it, so the host's welcome page is returned. Because no upstream hosts are pre-defined in the Backend, you can send a request to any reachable host without changing the configuration. For example, for quick testing, you might send a request with the host header set to an in-cluster service, such as `httpbin.httpbin.svc.cluster.local:8000`.
    {{< tabs tabTotal="2" items="Cloud Provider LoadBalancer,Port forward for local testing" >}}
    {{% tab tabName="Cloud Provider LoadBalancer" %}}
    ```sh

--- a/assets/agw-docs/pages/traffic-management/dfp.md
+++ b/assets/agw-docs/pages/traffic-management/dfp.md
@@ -78,13 +78,13 @@ EOF
 
 {{< doc-test paths="dfp" >}}
 YAMLTest -f - <<'EOF'
-- name: dfp - request with host httpbin.org returns 200
+- name: dfp - request with host httpbin.httpbin.svc.cluster.local returns 200
   retries: 5
   http:
     url: "http://${INGRESS_GW_ADDRESS}:80"
     method: GET
     headers:
-      host: httpbin.org
+      host: httpbin.httpbin.svc.cluster.local:8000
   source:
     type: local
   expect:
@@ -92,19 +92,28 @@ YAMLTest -f - <<'EOF'
 EOF
 {{< /doc-test >}}
 
-3. Send a request to a hostname of your choice, such as `httpbin.org`. Verify that your gateway proxy successfully resolves the `httpbin.org` host and returns its welcome page.
+3. Send a request to a hostname of your choice, such as `httpbin.org`. The Dynamic Forward Proxy resolves the host at request time and forwards the request to it, so the host's welcome page is returned. Because no upstream hosts are pre-defined in the Backend, you can send a request to any reachable host without changing the configuration.
    {{< tabs tabTotal="2" items="Cloud Provider LoadBalancer,Port forward for local testing" >}}
    {{% tab tabName="Cloud Provider LoadBalancer" %}}
    ```sh
-   curl -vik http://$INGRESS_GW_ADDRESS:8080 -H "host: httpbin.org" 
+   curl -vik http://$INGRESS_GW_ADDRESS:80 -H "host: httpbin.org" 
    ```
    {{% /tab %}}
    {{% tab tabName="Port forward for local testing" %}}
-   ```sh
-   curl -vik http://localhost:8080 -H "host: httpbin.org"
-   ```
+   1. Port-forward the gateway proxy on port 8080.
+      ```sh
+      kubectl port-forward deployment/agentgateway-proxy -n {{< reuse "agw-docs/snippets/namespace.md" >}} 8080:80
+      ```
+   2. Send a request to the gateway proxy.
+      ```sh
+      curl -vik http://localhost:8080 -H "host: httpbin.org"
+      ```
    {{% /tab %}}
    {{< /tabs >}}
+
+   {{< callout type="info" >}}
+   The Dynamic Forward Proxy resolves any reachable host, including in-cluster services. To verify the proxy without depending on an external site, send a request with the host header set to an in-cluster service, such as `httpbin.httpbin.svc.cluster.local:8000`.
+   {{< /callout >}}
    
    Example output: 
    ```console
@@ -118,8 +127,6 @@ EOF
    <head>
         <meta charset="UTF-8">
         <title>httpbin.org</title>
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700"
-            rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="/flasgger_static/swagger-ui.css">
         <link rel="icon" type="image/png" href="/static/favicon.ico" sizes="64x64 32x32 16x16" />
         <style>


### PR DESCRIPTION
This change fixes the recurring CI failure in the Dynamic Forward Proxy doc test, which was caused by the test depending on the live public httpbin.org. That host is a free, frequently-overloaded service, and it returned 503 Service Unavailable from its own load balancer, turning the test red for reasons unrelated to agentgateway or the docs. Because a CI test can only be reliable if it depends solely on resources under its control, the hidden test assertion now targets the in-cluster httpbin service (httpbin.httpbin.svc.cluster.local:8000) instead of the public internet, making it hermetic and immune to third-party outages. The visible documentation still demonstrates egress to an external host (httpbin.org) so readers understand the real use case for a forward proxy, and a callout points to the in-cluster address for anyone who wants to verify the proxy without relying on an external site. This change also corrects a pre-existing error in the page's example commands, which used port 8080 directly against the LoadBalancer (it listens on 80) and omitted the kubectl port-forward step in the local-testing tab, both of which caused connection-refused errors when followed by hand.