### PR TITLE
agw-standalone feedback: llm/content-routing - simplify CEL express...

### DIFF
--- a/assets/agw-docs/pages/agentgateway/llm/content-routing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/content-routing.md
@@ -385,29 +385,29 @@ This example shows routing based on a custom `priority` field in the request bod
    EOF
    ```
 
-3. Create a {{< reuse "agw-docs/snippets/trafficpolicy.md" >}} to extract the custom field. Use the `has()` macro to provide a default value if the field is not present. This policy must target the Gateway with `phase: PreRouting` to run before route selection.
+3. Create a {{< reuse "agw-docs/snippets/trafficpolicy.md" >}} to extract the custom field. Use the `coalesce()` function to provide a default value if the field is not present. This policy must target the Gateway with `phase: PreRouting` to run before route selection.
 
-   ```yaml
-   kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/trafficpolicy-apiversion.md" >}}
-   kind: {{< reuse "agw-docs/snippets/trafficpolicy.md" >}}
-   metadata:
-     name: extract-priority
-     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
-   spec:
-     targetRefs:
-     - group: gateway.networking.k8s.io
-       kind: Gateway
-       name: agentgateway-proxy
-     traffic:
-       phase: PreRouting
-       transformation:
-         request:
-           set:
-           - name: "x-priority"
-             value: 'has(json(request.body).priority) ? json(request.body).priority : "standard"'
-   EOF
-   ```
+    ```yaml
+    kubectl apply -f- <<EOF
+    apiVersion: {{< reuse "agw-docs/snippets/trafficpolicy-apiversion.md" >}}
+    kind: {{< reuse "agw-docs/snippets/trafficpolicy.md" >}}
+    metadata:
+      name: extract-priority
+      namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+    spec:
+      targetRefs:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: agentgateway-proxy
+      traffic:
+        phase: PreRouting
+        transformation:
+          request:
+            set:
+            - name: "x-priority"
+              value: 'coalesce(json(request.body).priority, "standard")'
+    EOF
+    ```
 
 4. Test the routing by sending requests with different priority values.
 

--- a/assets/agw-docs/pages/agentgateway/llm/content-routing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/content-routing.md
@@ -387,27 +387,27 @@ This example shows routing based on a custom `priority` field in the request bod
 
 3. Create a {{< reuse "agw-docs/snippets/trafficpolicy.md" >}} to extract the custom field. Use the `coalesce()` function to provide a default value if the field is not present. This policy must target the Gateway with `phase: PreRouting` to run before route selection.
 
-    ```yaml
-    kubectl apply -f- <<EOF
-    apiVersion: {{< reuse "agw-docs/snippets/trafficpolicy-apiversion.md" >}}
-    kind: {{< reuse "agw-docs/snippets/trafficpolicy.md" >}}
-    metadata:
-      name: extract-priority
-      namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
-    spec:
-      targetRefs:
-      - group: gateway.networking.k8s.io
-        kind: Gateway
-        name: agentgateway-proxy
-      traffic:
-        phase: PreRouting
-        transformation:
-          request:
-            set:
-            - name: "x-priority"
-              value: 'coalesce(json(request.body).priority, "standard")'
-    EOF
-    ```
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: {{< reuse "agw-docs/snippets/trafficpolicy-apiversion.md" >}}
+   kind: {{< reuse "agw-docs/snippets/trafficpolicy.md" >}}
+   metadata:
+     name: extract-priority
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     targetRefs:
+     - group: gateway.networking.k8s.io
+       kind: Gateway
+       name: agentgateway-proxy
+     traffic:
+       phase: PreRouting
+       transformation:
+         request:
+           set:
+           - name: "x-priority"
+             value: 'coalesce(json(request.body).priority, "standard")'
+   EOF
+   ```
 
 4. Test the routing by sending requests with different priority values.
 

--- a/content/docs/standalone/latest/llm/content-routing.md
+++ b/content/docs/standalone/latest/llm/content-routing.md
@@ -185,7 +185,7 @@ binds:
         transformations:
           request:
             set:
-              x-priority: 'has(json(request.body).priority) ? json(request.body).priority : "standard"'
+              x-priority: 'coalesce(json(request.body).priority, "standard")'
         cors:
           allowOrigins:
             - "*"
@@ -207,7 +207,7 @@ binds:
         transformations:
           request:
             set:
-              x-priority: 'has(json(request.body).priority) ? json(request.body).priority : "standard"'
+              x-priority: 'coalesce(json(request.body).priority, "standard")'
         cors:
           allowOrigins:
             - "*"
@@ -217,7 +217,7 @@ EOF
 ```
 
 {{< callout type="info" >}}
-The `has()` macro checks if a field exists in the JSON body before accessing it. This provides a default value if the field is missing, preventing errors when the custom field is not included in requests.
+The `coalesce()` function returns the first non-null value from its arguments. This provides a default value if the field is missing, preventing errors when the custom field is not included in requests.
 {{< /callout >}}
 
 Test the routing by sending requests with different priority values:

--- a/content/docs/standalone/main/llm/content-routing.md
+++ b/content/docs/standalone/main/llm/content-routing.md
@@ -185,7 +185,7 @@ binds:
         transformations:
           request:
             set:
-              x-priority: 'has(json(request.body).priority) ? json(request.body).priority : "standard"'
+              x-priority: 'coalesce(json(request.body).priority, "standard")'
         cors:
           allowOrigins:
             - "*"
@@ -207,7 +207,7 @@ binds:
         transformations:
           request:
             set:
-              x-priority: 'has(json(request.body).priority) ? json(request.body).priority : "standard"'
+              x-priority: 'coalesce(json(request.body).priority, "standard")'
         cors:
           allowOrigins:
             - "*"
@@ -217,7 +217,7 @@ EOF
 ```
 
 {{< callout type="info" >}}
-The `has()` macro checks if a field exists in the JSON body before accessing it. This provides a default value if the field is missing, preventing errors when the custom field is not included in requests.
+The `coalesce()` function returns the first non-null value from its arguments. This provides a default value if the field is missing, preventing errors when the custom field is not included in requests.
 {{< /callout >}}
 
 Test the routing by sending requests with different priority values:


### PR DESCRIPTION
Replace the verbose CEL ternary expression `has(json(request.body).priority) ? json(request.body).priority : "standard"` with the simplified `coalesce(json(request.body).priority, "standard")` in all .

Closes #2448