### PR TITLE
agw-standalone feedback: integrations/llm-observability - send dire...

### DIFF
--- a/content/docs/standalone/latest/integrations/llm-observability/langfuse.md
+++ b/content/docs/standalone/latest/integrations/llm-observability/langfuse.md
@@ -35,36 +35,13 @@ Sign up at [langfuse.com](https://langfuse.com/) and get your API keys.
 
 ## Configuration
 
-Langfuse accepts OpenTelemetry traces. Configure an OTEL Collector to forward traces:
-
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-exporters:
-  otlphttp:
-    endpoint: https://cloud.langfuse.com/api/public/otel
-    headers:
-      Authorization: "Basic <base64-encoded-public-key:secret-key>"
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp]
-```
-
-Configure agentgateway:
+Langfuse accepts OpenTelemetry traces directly. Configure agentgateway to export traces directly to your Langfuse deployment:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 config:
   tracing:
-    otlpEndpoint: http://localhost:4317
+    otlpEndpoint: https://cloud.langfuse.com/api/public/otel
     randomSampling: true
 
 binds:
@@ -82,7 +59,31 @@ binds:
           key: "$OPENAI_API_KEY"
 ```
 
+### Authentication
+
+Langfuse Cloud requires Basic Authentication for direct OTLP export. To authenticate, set the `OTEL_EXPORTER_OTLP_HEADERS` environment variable with your Langfuse API credentials:
+
+```bash
+# Base64-encode your Langfuse public key and secret key
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n 'your-public-key:your-secret-key' | base64)"
+
+# Also set the protocol to HTTP/protobuf (Langfuse Cloud requires HTTP, not gRPC)
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+If you're using a self-hosted Langfuse instance that doesn't require authentication, you can omit the `OTEL_EXPORTER_OTLP_HEADERS` variable and point directly to your instance:
+
+```yaml
+# For self-hosted Langfuse
+config:
+  tracing:
+    otlpEndpoint: http://localhost:4317  # or your self-hosted instance URL
+    randomSampling: true
+```
+
 ## Docker Compose example
+
+For **Langfuse Cloud**, agentgateway exports traces directly without needing an OTel Collector:
 
 ```yaml
 version: '3'
@@ -93,16 +94,22 @@ services:
       - "3000:3000"
     volumes:
       - ./config.yaml:/etc/agentgateway/config.yaml
-    depends_on:
-      - otel-collector
+    environment:
+      - OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic ${LANGFUSE_AUTH_HEADER}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
 
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+For **self-hosted Langfuse**, you can point agentgateway directly to your instance:
+
+```yaml
+version: '3'
+services:
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:latest
     ports:
-      - "4317:4317"
+      - "3000:3000"
     volumes:
-      - ./otel-collector-config.yaml:/etc/otel/config.yaml
-    command: ["--config", "/etc/otel/config.yaml"]
+      - ./config.yaml:/etc/agentgateway/config.yaml
 
   langfuse:
     image: langfuse/langfuse:latest

--- a/content/docs/standalone/latest/integrations/llm-observability/langsmith.md
+++ b/content/docs/standalone/latest/integrations/llm-observability/langsmith.md
@@ -18,40 +18,16 @@ description: Integrate agentgateway with LangSmith for LLM debugging and monitor
 
 1. Sign up at [smith.langchain.com](https://smith.langchain.com/)
 2. Create a project and get your API key
-3. Configure the OpenTelemetry Collector to forward traces
 
 ## Configuration
 
-LangSmith accepts OpenTelemetry traces via their OTLP endpoint:
-
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-exporters:
-  otlphttp:
-    endpoint: https://api.smith.langchain.com/otel
-    headers:
-      x-api-key: "${LANGSMITH_API_KEY}"
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp]
-```
-
-Configure agentgateway:
+LangSmith accepts OpenTelemetry traces directly. Configure agentgateway to export traces directly to LangSmith:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 config:
   tracing:
-    otlpEndpoint: http://localhost:4317
+    otlpEndpoint: https://api.smith.langchain.com/otel
     randomSampling: true
 
 binds:
@@ -67,6 +43,36 @@ binds:
       policies:
         backendAuth:
           key: "$OPENAI_API_KEY"
+```
+
+### Authentication
+
+LangSmith requires an API key for authentication. Set the `OTEL_EXPORTER_OTLP_HEADERS` environment variable with your LangSmith API key:
+
+```bash
+# Set the x-api-key header for LangSmith authentication
+export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=your-langsmith-api-key"
+
+# Also set the protocol to HTTP/protobuf (LangSmith requires HTTP, not gRPC)
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+## Docker Compose example
+
+Agentgateway exports traces directly to LangSmith without needing an OTel Collector:
+
+```yaml
+version: '3'
+services:
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config.yaml:/etc/agentgateway/config.yaml
+    environment:
+      - OTEL_EXPORTER_OTLP_HEADERS=x-api-key=${LANGSMITH_API_KEY}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
 
 ## Learn more

--- a/content/docs/standalone/latest/integrations/llm-observability/phoenix.md
+++ b/content/docs/standalone/latest/integrations/llm-observability/phoenix.md
@@ -72,14 +72,21 @@ services:
       - "3000:3000"
     volumes:
       - ./config.yaml:/etc/agentgateway/config.yaml
-    environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:4317
 
   phoenix:
     image: arizephoenix/phoenix:latest
     ports:
       - "6006:6006"
       - "4317:4317"
+```
+
+When using Docker Compose, update your config.yaml to use the Phoenix service name:
+
+```yaml
+config:
+  tracing:
+    otlpEndpoint: http://phoenix:4317
+    randomSampling: true
 ```
 
 ## Learn more

--- a/content/docs/standalone/latest/integrations/llm-observability/phoenix.md
+++ b/content/docs/standalone/latest/integrations/llm-observability/phoenix.md
@@ -33,30 +33,9 @@ Access Phoenix at [http://localhost:6006](http://localhost:6006).
 
 ## Configuration
 
-Phoenix accepts OpenTelemetry traces natively:
+Phoenix accepts OpenTelemetry traces natively on port 4317 (gRPC) and port 6006 (HTTP), so agentgateway can export traces directly to Phoenix without an intermediate OpenTelemetry Collector.
 
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-exporters:
-  otlp:
-    endpoint: http://localhost:4317
-    tls:
-      insecure: true
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlp]
-```
-
-Configure agentgateway:
+Configure agentgateway to send traces directly to Phoenix:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -81,6 +60,8 @@ binds:
 ```
 
 ## Docker Compose example
+
+Agentgateway exports traces directly to Phoenix without needing an OTel Collector:
 
 ```yaml
 version: '3'

--- a/content/docs/standalone/main/integrations/llm-observability/langfuse.md
+++ b/content/docs/standalone/main/integrations/llm-observability/langfuse.md
@@ -35,36 +35,13 @@ Sign up at [langfuse.com](https://langfuse.com/) and get your API keys.
 
 ## Configuration
 
-Langfuse accepts OpenTelemetry traces. Configure an OTEL Collector to forward traces:
-
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-exporters:
-  otlphttp:
-    endpoint: https://cloud.langfuse.com/api/public/otel
-    headers:
-      Authorization: "Basic <base64-encoded-public-key:secret-key>"
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp]
-```
-
-Configure agentgateway:
+Langfuse accepts OpenTelemetry traces directly. Configure agentgateway to export traces directly to your Langfuse deployment:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 config:
   tracing:
-    otlpEndpoint: http://localhost:4317
+    otlpEndpoint: https://cloud.langfuse.com/api/public/otel
     randomSampling: true
 
 binds:
@@ -82,7 +59,31 @@ binds:
           key: "$OPENAI_API_KEY"
 ```
 
+### Authentication
+
+Langfuse Cloud requires Basic Authentication for direct OTLP export. To authenticate, set the `OTEL_EXPORTER_OTLP_HEADERS` environment variable with your Langfuse API credentials:
+
+```bash
+# Base64-encode your Langfuse public key and secret key
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic $(echo -n 'your-public-key:your-secret-key' | base64)"
+
+# Also set the protocol to HTTP/protobuf (Langfuse Cloud requires HTTP, not gRPC)
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+If you're using a self-hosted Langfuse instance that doesn't require authentication, you can omit the `OTEL_EXPORTER_OTLP_HEADERS` variable and point directly to your instance:
+
+```yaml
+# For self-hosted Langfuse
+config:
+  tracing:
+    otlpEndpoint: http://localhost:4317  # or your self-hosted instance URL
+    randomSampling: true
+```
+
 ## Docker Compose example
+
+For **Langfuse Cloud**, agentgateway exports traces directly without needing an OTel Collector:
 
 ```yaml
 version: '3'
@@ -93,16 +94,22 @@ services:
       - "3000:3000"
     volumes:
       - ./config.yaml:/etc/agentgateway/config.yaml
-    depends_on:
-      - otel-collector
+    environment:
+      - OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic ${LANGFUSE_AUTH_HEADER}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
 
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+For **self-hosted Langfuse**, you can point agentgateway directly to your instance:
+
+```yaml
+version: '3'
+services:
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:latest
     ports:
-      - "4317:4317"
+      - "3000:3000"
     volumes:
-      - ./otel-collector-config.yaml:/etc/otel/config.yaml
-    command: ["--config", "/etc/otel/config.yaml"]
+      - ./config.yaml:/etc/agentgateway/config.yaml
 
   langfuse:
     image: langfuse/langfuse:latest

--- a/content/docs/standalone/main/integrations/llm-observability/langsmith.md
+++ b/content/docs/standalone/main/integrations/llm-observability/langsmith.md
@@ -18,40 +18,16 @@ description: Integrate agentgateway with LangSmith for LLM debugging and monitor
 
 1. Sign up at [smith.langchain.com](https://smith.langchain.com/)
 2. Create a project and get your API key
-3. Configure the OpenTelemetry Collector to forward traces
 
 ## Configuration
 
-LangSmith accepts OpenTelemetry traces via their OTLP endpoint:
-
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-exporters:
-  otlphttp:
-    endpoint: https://api.smith.langchain.com/otel
-    headers:
-      x-api-key: "${LANGSMITH_API_KEY}"
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp]
-```
-
-Configure agentgateway:
+LangSmith accepts OpenTelemetry traces directly. Configure agentgateway to export traces directly to LangSmith:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 config:
   tracing:
-    otlpEndpoint: http://localhost:4317
+    otlpEndpoint: https://api.smith.langchain.com/otel
     randomSampling: true
 
 binds:
@@ -67,6 +43,36 @@ binds:
       policies:
         backendAuth:
           key: "$OPENAI_API_KEY"
+```
+
+### Authentication
+
+LangSmith requires an API key for authentication. Set the `OTEL_EXPORTER_OTLP_HEADERS` environment variable with your LangSmith API key:
+
+```bash
+# Set the x-api-key header for LangSmith authentication
+export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=your-langsmith-api-key"
+
+# Also set the protocol to HTTP/protobuf (LangSmith requires HTTP, not gRPC)
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+## Docker Compose example
+
+Agentgateway exports traces directly to LangSmith without needing an OTel Collector:
+
+```yaml
+version: '3'
+services:
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config.yaml:/etc/agentgateway/config.yaml
+    environment:
+      - OTEL_EXPORTER_OTLP_HEADERS=x-api-key=${LANGSMITH_API_KEY}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
 
 ## Learn more

--- a/content/docs/standalone/main/integrations/llm-observability/phoenix.md
+++ b/content/docs/standalone/main/integrations/llm-observability/phoenix.md
@@ -72,14 +72,21 @@ services:
       - "3000:3000"
     volumes:
       - ./config.yaml:/etc/agentgateway/config.yaml
-    environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://phoenix:4317
 
   phoenix:
     image: arizephoenix/phoenix:latest
     ports:
       - "6006:6006"
       - "4317:4317"
+```
+
+When using Docker Compose, update your config.yaml to use the Phoenix service name:
+
+```yaml
+config:
+  tracing:
+    otlpEndpoint: http://phoenix:4317
+    randomSampling: true
 ```
 
 ## Learn more

--- a/content/docs/standalone/main/integrations/llm-observability/phoenix.md
+++ b/content/docs/standalone/main/integrations/llm-observability/phoenix.md
@@ -33,30 +33,9 @@ Access Phoenix at [http://localhost:6006](http://localhost:6006).
 
 ## Configuration
 
-Phoenix accepts OpenTelemetry traces natively:
+Phoenix accepts OpenTelemetry traces natively on port 4317 (gRPC) and port 6006 (HTTP), so agentgateway can export traces directly to Phoenix without an intermediate OpenTelemetry Collector.
 
-```yaml
-# otel-collector-config.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-
-exporters:
-  otlp:
-    endpoint: http://localhost:4317
-    tls:
-      insecure: true
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlp]
-```
-
-Configure agentgateway:
+Configure agentgateway to send traces directly to Phoenix:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -81,6 +60,8 @@ binds:
 ```
 
 ## Docker Compose example
+
+Agentgateway exports traces directly to Phoenix without needing an OTel Collector:
 
 ```yaml
 version: '3'


### PR DESCRIPTION
Rewrite each standalone LLM observability integration page to show direct OTLP export from agentgateway to the target platform (Langfuse, LangSmith, Phoenix), eliminating the intermediate OpenTelemetr.

Closes #2466