### PR TITLE
agw-standalone feedback: integrations/llm-clients/claude-code - cla...

### DIFF
--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md
@@ -7,9 +7,15 @@ The primary use case is routing Claude Code to non-Anthropic LLM backends (such 
 1. {{< reuse "agw-docs/snippets/prereq-agentgateway.md" >}}
 2. Install the [Claude Code CLI](https://code.claude.com/docs) (`npm install -g @anthropic-ai/claude-code`).
 
+{{< alert type="info" >}}
+The `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` environment variable disables Claude Code's experimental beta features. You typically **do not need** this variable when proxying to non-Anthropic backends or standard Anthropic routing.
+
+Only set this variable if you encounter errors like `Extra inputs are not permitted` when using advanced Anthropic features (such as experimental translation or extended thinking). If you use a non-Anthropic backend, this variable can be safely omitted.
+{{< /alert >}}
+
 ## Configure agentgateway with OpenAI-compatible backend
 
-Route Claude Code to any OpenAI-compatible LLM provider (e.g., vLLM, Ollama, or local language models). This is the recommended approach for cost-effective and flexible deployment.
+Route Claude Code to any OpenAI-compatible LLM provider (such as vLLM, Ollama, or local language models). This is the recommended approach for cost-effective and flexible deployment.
 
 1. Create a configuration file with an OpenAI-compatible provider. The wildcard `*` model name accepts any model. Claude Code sends the model in each request, so you do not need to pin a specific model.
 
@@ -49,12 +55,6 @@ Route Claude Code to any OpenAI-compatible LLM provider (e.g., vLLM, Ollama, or 
    ```bash
    claude -p "Hello"
    ```
-
-## About CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS
-
-The `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` environment variable disables Claude Code's experimental beta features. You typically **do not need** this variable when proxying to non-Anthropic backends or standard Anthropic routing.
-
-Only set this variable if you encounter errors like `Extra inputs are not permitted` when using advanced Anthropic features (e.g., experimental translation or extended thinking). If you use a non-Anthropic backend, this variable can be safely omitted.
 
 ## Configure agentgateway with Anthropic backend
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md
@@ -1,24 +1,82 @@
 Configure [Claude Code](https://code.claude.com/docs), the AI coding CLI by Anthropic, to route LLM requests through your agentgateway proxy.
 
+The primary use case is routing Claude Code to non-Anthropic LLM backends (such as vLLM, Ollama, or any OpenAI-compatible provider) for cost optimization and flexibility. You can also configure direct routing to Anthropic or use a Claude Teams account as alternative options.
+
 ## Before you begin
 
 1. {{< reuse "agw-docs/snippets/prereq-agentgateway.md" >}}
 2. Install the [Claude Code CLI](https://code.claude.com/docs) (`npm install -g @anthropic-ai/claude-code`).
-3. Get an Anthropic API key from the [Anthropic Console](https://platform.claude.com).
 
-## Configure agentgateway
+## Configure agentgateway with OpenAI-compatible backend
 
-Start agentgateway with an Anthropic backend configuration.
+Route Claude Code to any OpenAI-compatible LLM provider (e.g., vLLM, Ollama, or local language models). This is the recommended approach for cost-effective and flexible deployment.
 
-1. Export your Anthropic API key.
+1. Create a configuration file with an OpenAI-compatible provider. The wildcard `*` model name accepts any model. Claude Code sends the model in each request, so you do not need to pin a specific model.
+
+   ```yaml {paths="claude-code-openai-validate"}
+   cat > config.yaml << 'EOF'
+   # yaml-language-server: $schema=https://agentgateway.dev/schema/config
+   llm:
+     models:
+     - name: "*"
+       provider: openai
+       params:
+         baseURL: "http://localhost:8000/v1"  # vLLM or similar OpenAI-compatible endpoint
+         apiKey: "mock-key"  # Not used for local providers, but required by config
+   EOF
+   ```
+
+   Replace `http://localhost:8000/v1` with your OpenAI-compatible provider's endpoint.
+
+   {{< doc-test paths="claude-code-openai-validate" >}}
+   mkdir -p "$HOME/.local/bin"
+   export PATH="$HOME/.local/bin:$PATH"
+   VERSION="v{{< reuse "agw-docs/versions/n-patch.md" >}}"
+   BINARY_URL="https://github.com/agentgateway/agentgateway/releases/download/${VERSION}/agentgateway-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/')"
+   curl -sL "$BINARY_URL" -o "$HOME/.local/bin/agentgateway"
+   chmod +x "$HOME/.local/bin/agentgateway"
+   agentgateway -f config.yaml --validate-only
+   {{< /doc-test >}}
+
+2. Start agentgateway.
+
+   ```bash
+   agentgateway -f config.yaml
+   ```
+
+3. Configure Claude Code to point to your agentgateway instance.
+
+   ```bash
+   export ANTHROPIC_BASE_URL="http://localhost:4000"
+   ```
+
+4. Verify the connection.
+
+   ```bash
+   claude -p "Hello"
+   ```
+
+## About CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS
+
+The `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` environment variable disables Claude Code's experimental beta features. You typically **do not need** this variable when proxying to non-Anthropic backends or standard Anthropic routing.
+
+Only set this variable if you encounter errors like `Extra inputs are not permitted` when using advanced Anthropic features (e.g., experimental translation or extended thinking). If you use a non-Anthropic backend, this variable can be safely omitted.
+
+## Configure agentgateway with Anthropic backend
+
+Alternatively, route Claude Code directly to Anthropic's API through agentgateway. This is useful if you want to leverage Anthropic's latest models or features directly.
+
+1. Get an Anthropic API key from the [Anthropic Console](https://platform.claude.com).
+
+2. Export your Anthropic API key.
 
    ```bash
    export ANTHROPIC_API_KEY="sk-ant-your-key-here"
    ```
 
-2. Create a configuration file with the Anthropic provider. The wildcard `*` model name accepts any model. Claude Code sends the model in each request, so you do not need to pin a specific model.
+3. Create a configuration file with the Anthropic provider. The wildcard `*` model name accepts any model. Claude Code sends the model in each request, so you do not need to pin a specific model.
 
-   ```yaml {paths="claude-code-validate"}
+   ```yaml {paths="claude-code-anthropic-validate"}
    cat > config.yaml << 'EOF'
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
    llm:
@@ -30,7 +88,7 @@ Start agentgateway with an Anthropic backend configuration.
    EOF
    ```
 
-   {{< doc-test paths="claude-code-validate" >}}
+   {{< doc-test paths="claude-code-anthropic-validate" >}}
    mkdir -p "$HOME/.local/bin"
    export PATH="$HOME/.local/bin:$PATH"
    VERSION="v{{< reuse "agw-docs/versions/n-patch.md" >}}"
@@ -41,44 +99,28 @@ Start agentgateway with an Anthropic backend configuration.
    agentgateway -f config.yaml --validate-only
    {{< /doc-test >}}
 
-3. Start agentgateway.
+4. Start agentgateway.
 
    ```bash
    agentgateway -f config.yaml
    ```
 
-{{< callout type="info" >}}
-For pinned model configuration, extended thinking, and other options, see the [Anthropic provider page]({{< link-hextra path="/llm/providers/anthropic" >}}).
-{{< /callout >}}
+5. Configure Claude Code.
 
-## Configure Claude Code
+   ```bash
+   export ANTHROPIC_BASE_URL="http://localhost:4000"
+   ```
 
-Set the `ANTHROPIC_BASE_URL` environment variable to point Claude Code at your agentgateway instance.
-
-```bash
-export ANTHROPIC_BASE_URL="http://localhost:4000"
-```
-
-## Verify the connection
-
-1. Send a single test prompt through agentgateway.
+6. Verify the connection.
 
    ```bash
    claude -p "Hello"
    ```
 
    Example output:
-   
+
    ```
    Hello! How can I help you today?
-   ```
-
-2. Verify that the request appears in the agentgateway logs.
-
-   Example output:
-
-   ```
-   info  request gateway=default/default listener=llm route=internal/model:* endpoint=api.anthropic.com:443 http.method=POST http.path=/v1/messages http.status=200 protocol=llm gen_ai.operation.name=chat gen_ai.provider.name=anthropic gen_ai.request.model=claude-haiku-4-5-20251001 gen_ai.usage.input_tokens=14 gen_ai.usage.output_tokens=9 gen_ai.request.max_tokens=50 duration=1687ms
    ```
 
    If you see an error like `API Error: 400 context_management: Extra inputs are not permitted`, Claude Code is sending experimental beta parameters that agentgateway does not yet support. Disable experimental betas and retry the request.
@@ -88,17 +130,13 @@ export ANTHROPIC_BASE_URL="http://localhost:4000"
    claude -p "Hello"
    ```
 
-3. Optionally, start Claude Code in interactive mode with all traffic routed through agentgateway.
+{{< callout type="info" >}}
+For pinned model configuration, extended thinking, and other options, see the [Anthropic provider page]({{< link-hextra path="/llm/providers/anthropic" >}}).
+{{< /callout >}}
 
-   ```bash
-   claude
-   ```
+## Claude Teams or Pro account
 
-   All requests, including prompts, tool calls, and file reads, flow through agentgateway.
-
-## Teams account
-
-If you have a Claude Teams or Pro account, use this configuration instead of the API key setup above. No API key is required — authentication is handled by your Claude subscription via OAuth.
+If you have a Claude Teams or Pro account, you can use agentgateway for request routing without an API key. Authentication is handled by your Claude subscription via OAuth.
 
 1. Create a configuration file. Agentgateway listens on port `4001` and exposes Claude at the `/claude` path.
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md
@@ -19,7 +19,7 @@ Route Claude Code to any OpenAI-compatible LLM provider (e.g., vLLM, Ollama, or 
    llm:
      models:
      - name: "*"
-       provider: openai
+       provider: openAI
        params:
          baseURL: "http://localhost:8000/v1"  # vLLM or similar OpenAI-compatible endpoint
          apiKey: "mock-key"  # Not used for local providers, but required by config
@@ -29,12 +29,6 @@ Route Claude Code to any OpenAI-compatible LLM provider (e.g., vLLM, Ollama, or 
    Replace `http://localhost:8000/v1` with your OpenAI-compatible provider's endpoint.
 
    {{< doc-test paths="claude-code-openai-validate" >}}
-   mkdir -p "$HOME/.local/bin"
-   export PATH="$HOME/.local/bin:$PATH"
-   VERSION="v{{< reuse "agw-docs/versions/n-patch.md" >}}"
-   BINARY_URL="https://github.com/agentgateway/agentgateway/releases/download/${VERSION}/agentgateway-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/')"
-   curl -sL "$BINARY_URL" -o "$HOME/.local/bin/agentgateway"
-   chmod +x "$HOME/.local/bin/agentgateway"
    agentgateway -f config.yaml --validate-only
    {{< /doc-test >}}
 
@@ -89,12 +83,6 @@ Alternatively, route Claude Code directly to Anthropic's API through agentgatewa
    ```
 
    {{< doc-test paths="claude-code-anthropic-validate" >}}
-   mkdir -p "$HOME/.local/bin"
-   export PATH="$HOME/.local/bin:$PATH"
-   VERSION="v{{< reuse "agw-docs/versions/n-patch.md" >}}"
-   BINARY_URL="https://github.com/agentgateway/agentgateway/releases/download/${VERSION}/agentgateway-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/')"
-   curl -sL "$BINARY_URL" -o "$HOME/.local/bin/agentgateway"
-   chmod +x "$HOME/.local/bin/agentgateway"
    export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-test}"
    agentgateway -f config.yaml --validate-only
    {{< /doc-test >}}
@@ -192,5 +180,5 @@ If you have a Claude Teams or Pro account, you can use agentgateway for request 
 
 {{< cards >}}
   {{< card path="/llm/providers/anthropic" title="Anthropic provider" subtitle="Complete Anthropic provider configuration" >}}
-  {{< card path="/llm/prompt-guards/" title="Prompt guards" subtitle="Set up guardails for LLM requests and responses" >}}
+  {{< card path="/llm/prompt-guards/" title="Prompt guards" subtitle="Set up guardrails for LLM requests and responses" >}}
 {{< /cards >}}


### PR DESCRIPTION
Restructure the Claude Code integration documentation to emphasize non-Anthropic LLM backends as the primary use case.

Closes #2468