### PR TITLE
agw-standalone feedback: integrations/auth pages - audit for halluc...

### DIFF
--- a/content/docs/standalone/latest/integrations/auth/_index.md
+++ b/content/docs/standalone/latest/integrations/auth/_index.md
@@ -15,6 +15,6 @@ Agentgateway supports several authentication approaches.
 |--------|----------|-----------|
 | JWT validation | API authentication | [JWT authentication]({{< link-hextra path="/configuration/security/jwt-authn" >}}) |
 | OIDC browser auth | Browser-based user authentication | [OIDC browser authentication]({{< link-hextra path="/configuration/security/oidc" >}}) |
-| OAuth2/OIDC (external) | User authentication via proxy | [OAuth2 Proxy]({{< link-hextra path="/integrations/auth/oauth2-proxy" >}}) |
+| OAuth2 Proxy | Browser authentication via a proxy | [OAuth2 Proxy]({{< link-hextra path="/integrations/auth/oauth2-proxy" >}}) |
 | External authz | Custom auth services | [External authorization]({{< link-hextra path="/configuration/security/external-authz" >}}) |
 | Tailscale | Zero-trust networks | [Tailscale]({{< link-hextra path="/integrations/auth/tailscale" >}}) |

--- a/content/docs/standalone/latest/integrations/auth/auth0.md
+++ b/content/docs/standalone/latest/integrations/auth/auth0.md
@@ -39,8 +39,6 @@ binds:
       policies:
         mcpAuthentication:
           issuer: https://your-tenant.auth0.com/
-          audiences:
-          - https://api.example.com
           jwks:
             url: https://your-tenant.auth0.com/.well-known/jwks.json
           resourceMetadata:

--- a/content/docs/standalone/latest/integrations/auth/auth0.md
+++ b/content/docs/standalone/latest/integrations/auth/auth0.md
@@ -1,10 +1,10 @@
 ---
 title: Auth0
 weight: 30
-description: Integrate agentgateway with Auth0 for identity management
+description: Use Auth0 access tokens with agentgateway
 ---
 
-[Auth0](https://auth0.com/) is an identity platform that provides authentication and authorization services. agentgateway can validate JWTs issued by Auth0.
+[Auth0](https://auth0.com/) is an identity platform that provides authentication and authorization services. agentgateway can validate access tokens issued by Auth0 with `mcpAuthentication`.
 
 ## Why use Auth0 with agentgateway?
 
@@ -12,11 +12,11 @@ description: Integrate agentgateway with Auth0 for identity management
 - **Social login** - Google, GitHub, Microsoft, and more
 - **Enterprise SSO** - SAML, LDAP, Active Directory
 - **MFA** - Built-in multi-factor authentication
-- **API protection** - JWT-based API authentication
+- **API protection** - JWT-based token validation for MCP services
 
 ## Configuration
 
-Configure agentgateway to validate Auth0 JWTs:
+Configure agentgateway to validate Auth0 tokens and publish MCP protected-resource metadata:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -31,19 +31,29 @@ binds:
             stdio:
               cmd: npx
               args: ["@modelcontextprotocol/server-everything"]
+      matches:
+      - path:
+          exact: /mcp
+      - path:
+          exact: /.well-known/oauth-protected-resource/mcp
       policies:
         mcpAuthentication:
-          mode: strict
           issuer: https://your-tenant.auth0.com/
           audiences:
           - https://api.example.com
           jwks:
             url: https://your-tenant.auth0.com/.well-known/jwks.json
+          resourceMetadata:
+            resource: https://gateway.example.com/mcp
+            scopesSupported:
+            - read:all
+            bearerMethodsSupported:
+            - header
 ```
 
 ## Auth0 setup
 
-1. Create an API in Auth0 Dashboard:
+1. Create an API in the Auth0 Dashboard:
    - Name: `agentgateway API`
    - Identifier: `https://api.example.com`
 
@@ -51,7 +61,7 @@ binds:
    - Type: Single Page Application or Machine to Machine
    - Note the Client ID and Client Secret
 
-3. Configure allowed callbacks and origins
+3. Configure the allowed callbacks and origins for any browser clients that will obtain tokens from Auth0.
 
 ## Getting a token
 
@@ -77,25 +87,13 @@ curl http://localhost:3000/mcp \
   -d '{"jsonrpc":"2.0","method":"initialize",...}'
 ```
 
-## Permission-based authorization
+## Authorization
 
-Use Auth0 permissions with agentgateway:
-
-```yaml
-policies:
-  mcpAuthentication:
-    mode: strict
-    issuer: https://your-tenant.auth0.com/
-    audiences: [https://api.example.com]
-    jwks:
-      url: https://your-tenant.auth0.com/.well-known/jwks.json
-  authorization:
-    rules:
-    # Check for specific permission
-    - '"read:tools" in jwt.permissions'
-```
+Auth0 does not require a provider-specific authorization schema in agentgateway. If you need authorization, use the generic [HTTP authorization]({{< link-hextra path="/configuration/security/http-authz" >}}) or [MCP authorization]({{< link-hextra path="/mcp/mcp-authz" >}}) policies against claims that your Auth0 tenant actually emits.
 
 ## Learn more
 
 - [Auth0 Documentation](https://auth0.com/docs)
 - [MCP authentication]({{< link-hextra path="/configuration/security/mcp-authn" >}})
+- [HTTP authorization]({{< link-hextra path="/configuration/security/http-authz" >}})
+- [MCP authorization]({{< link-hextra path="/mcp/mcp-authz" >}})

--- a/content/docs/standalone/latest/integrations/auth/keycloak.md
+++ b/content/docs/standalone/latest/integrations/auth/keycloak.md
@@ -4,7 +4,7 @@ weight: 20
 description: Validate Keycloak tokens with agentgateway
 ---
 
-[Keycloak](https://www.keycloak.org/) is an open-source identity and access management solution. agentgateway can validate tokens issued by Keycloak for MCP and HTTP routes.
+[Keycloak](https://www.keycloak.org/) is an open-source identity and access management solution. agentgateway can validate tokens issued by Keycloak for MCP routes, and it can use OIDC browser authentication for HTTP routes.
 
 ## Why use Keycloak with agentgateway?
 

--- a/content/docs/standalone/latest/integrations/auth/keycloak.md
+++ b/content/docs/standalone/latest/integrations/auth/keycloak.md
@@ -1,21 +1,21 @@
 ---
 title: Keycloak
 weight: 20
-description: Integrate agentgateway with Keycloak for identity management
+description: Validate Keycloak tokens with agentgateway
 ---
 
-[Keycloak](https://www.keycloak.org/) is an open-source identity and access management solution. agentgateway can validate JWTs issued by Keycloak.
+[Keycloak](https://www.keycloak.org/) is an open-source identity and access management solution. agentgateway can validate tokens issued by Keycloak for MCP and HTTP routes.
 
 ## Why use Keycloak with agentgateway?
 
 - **Open source** - Self-hosted identity management
 - **Standards-based** - OAuth2, OIDC, SAML support
 - **Enterprise features** - User federation, SSO, MFA
-- **Fine-grained authorization** - Role and attribute-based access
+- **MCP support** - Use Keycloak as an OAuth authorization server for MCP clients
 
-## Configuration
+## MCP authentication
 
-Configure agentgateway to validate Keycloak JWTs:
+Use `mcpAuthentication` when agentgateway fronts an MCP server. This policy validates Keycloak access tokens and exposes MCP protected resource metadata. Because Keycloak exposes certificates at a non-standard endpoint, set `provider.keycloak` and point `jwks.url` to the realm certificate endpoint.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -26,79 +26,75 @@ binds:
     - backends:
       - mcp:
           targets:
-          - name: my-server
+          - name: tools
             stdio:
               cmd: npx
               args: ["@modelcontextprotocol/server-everything"]
+      matches:
+      - path:
+          exact: /mcp
+      - path:
+          exact: /.well-known/oauth-protected-resource/mcp
+      - path:
+          exact: /.well-known/oauth-authorization-server/mcp
+      - path:
+          exact: /.well-known/oauth-authorization-server/mcp/client-registration
       policies:
         mcpAuthentication:
-          mode: strict
           issuer: https://keycloak.example.com/realms/myrealm
-          audiences:
-          - agentgateway
           jwks:
             url: https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs
+          provider:
+            keycloak: {}
+          resourceMetadata:
+            resource: https://gateway.example.com/mcp
+            scopesSupported:
+            - read:all
+            bearerMethodsSupported:
+            - header
 ```
 
-## Docker Compose example
+If you only need agentgateway to validate tokens from Keycloak and do not need authorization-server proxy behavior, omit `provider.keycloak` and configure the standard `issuer`, `jwks`, and `resourceMetadata` fields as described in [MCP authentication]({{< link-hextra path="/configuration/security/mcp-authn" >}}).
+
+## Browser authentication
+
+Use the built-in `oidc` policy when browser users should sign in through Keycloak before reaching an HTTP backend. The gateway handles the authorization code flow with PKCE and validates the ID token.
 
 ```yaml
-version: '3'
-services:
-  agentgateway:
-    image: ghcr.io/agentgateway/agentgateway:latest
-    ports:
-      - "3000:3000"
-    volumes:
-      - ./config.yaml:/etc/agentgateway/config.yaml
-    depends_on:
-      - keycloak
-
-  keycloak:
-    image: quay.io/keycloak/keycloak:latest
-    ports:
-      - "8080:8080"
-    environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
-    command: start-dev
-
-  postgres:
-    image: postgres:15
-    environment:
-      - POSTGRES_DB=keycloak
-      - POSTGRES_USER=keycloak
-      - POSTGRES_PASSWORD=keycloak
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: localhost:18080
+      matches:
+      - path:
+          pathPrefix: /
+      policies:
+        oidc:
+          issuer: https://keycloak.example.com/realms/myrealm
+          clientId: agentgateway-browser
+          clientSecret: my-client-secret
+          redirectURI: https://gateway.example.com/oauth/callback
+          scopes:
+          - profile
+          - email
 ```
 
 ## Keycloak setup
 
 1. Create a realm (e.g., `myrealm`)
-2. Create a client for agentgateway:
-   - Client ID: `agentgateway`
-   - Client Protocol: `openid-connect`
-   - Access Type: `confidential` or `public`
-3. Create users and assign roles
+2. Create an OpenID Connect client for agentgateway.
+3. Configure valid redirect URIs for browser OIDC clients, such as `https://gateway.example.com/oauth/callback`.
+4. Request or map only the scopes and claims your gateway policies need.
 
-## Role-based authorization
+## Authorization
 
-Combine Keycloak roles with agentgateway authorization:
-
-```yaml
-policies:
-  mcpAuthentication:
-    mode: strict
-    issuer: https://keycloak.example.com/realms/myrealm
-    audiences: [agentgateway]
-    jwks:
-      url: https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs
-  authorization:
-    rules:
-    # Check for admin role in token
-    - '"admin" in jwt.realm_access.roles'
-```
+This page does not define a Keycloak-specific authorization schema. If you use authorization rules after Keycloak authentication, write them against the JWT claims that your realm actually emits and the generic agentgateway policy you attach, such as [HTTP authorization]({{< link-hextra path="/configuration/security/http-authz" >}}) or [MCP authorization]({{< link-hextra path="/mcp/mcp-authz" >}}). Avoid copying Keycloak role claim paths unless you have confirmed those claims are present in your tokens.
 
 ## Learn more
 
 - [Keycloak Documentation](https://www.keycloak.org/documentation)
 - [MCP authentication]({{< link-hextra path="/configuration/security/mcp-authn" >}})
+- [OIDC browser authentication]({{< link-hextra path="/configuration/security/oidc" >}})

--- a/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
+++ b/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
@@ -138,7 +138,7 @@ The following table describes the key settings in the configuration.
 | `frontendPolicies.accessLog.add` | Logs the authenticated user's identity and email. |
 | `routes` (`oauth2-proxy`) | Routes `/oauth2/*` requests to OAuth2 Proxy for login and callback handling. |
 | `routes` (`application`) | The protected MCP endpoint with external authorization. |
-| `extAuthz.includeRequestHeaders` | Forwards the browser session cookie to OAuth2 Proxy. |
+| `extAuthz.protocol.includeRequestHeaders` | Forwards the browser session cookie to OAuth2 Proxy. |
 | `extAuthz.host` | The OAuth2 Proxy address for authentication checks. |
 | `extAuthz.protocol.http.path` | The endpoint that OAuth2 Proxy uses to validate authentication. |
 | `extAuthz.protocol.http.redirect` | Where to send unauthenticated users. |

--- a/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
+++ b/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
@@ -110,14 +110,16 @@ binds:
           exposeHeaders: ["Mcp-Session-Id"]
         extAuthz:
           host: localhost:4180
-          includeRequestHeaders:
-          - cookie
           protocol:
+            includeRequestHeaders:
+            - cookie
             http:
               # Check authentication status
-              path: '"/oauth2/auth"'
+              path: |
+                "/oauth2/auth"
               # Redirect unauthenticated users to login
-              redirect: '"/oauth2/start?rd=" + request.path'
+              redirect: |
+                "/oauth2/start?rd=" + request.path
               addRequestHeaders:
                 x-forwarded-host: request.host
               includeResponseHeaders:

--- a/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
+++ b/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
@@ -4,9 +4,9 @@ weight: 25
 description: Add user authentication with GitHub, Google, Azure AD, and other OAuth providers by integrating agentgateway with OAuth2 Proxy.
 ---
 
-Agentgateway can integrate with [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) to add user authentication through GitHub, Google, Azure AD, and other OAuth providers. Agentgateway uses an [external authorization (`extAuthz`)]({{< link-hextra path="/configuration/security/external-authz" >}}) policy to delegate authentication checks to OAuth2 Proxy, which redirects unauthenticated users to the provider's login page.
+Agentgateway can integrate with [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) to add browser authentication through GitHub, Google, Azure AD, and other OAuth providers. Agentgateway uses an [external authorization (`extAuthz`)]({{< link-hextra path="/configuration/security/external-authz" >}}) policy to send authentication checks to OAuth2 Proxy, which handles the redirect to the provider's login page.
 
-This guide uses GitHub as the example provider. For other providers, see [Use other OAuth providers](#other-providers).
+This guide uses GitHub as the example provider. If you use another provider, only the OAuth2 Proxy flags change.
 
 ## Before you begin
 
@@ -76,9 +76,9 @@ Create a `config.yaml` file. The configuration routes `/oauth2/*` requests to OA
 frontendPolicies:
   accessLog:
     add:
-      # Log the authenticated user's GitHub username and email
-      github.user: 'extauthz.githubUser'
-      github.email: 'extauthz.githubEmail'
+      # Log the authenticated user's identity and email
+      oauth.user: extauthz.oauthUser
+      oauth.email: extauthz.oauthEmail
 
 binds:
 - port: 3000
@@ -91,9 +91,6 @@ binds:
       matches:
       - path:
           pathPrefix: /oauth2
-      policies:
-        urlRewrite:
-          authority: none
       backends:
       - host: localhost:4180
 
@@ -121,26 +118,29 @@ binds:
               path: '"/oauth2/auth"'
               # Redirect unauthenticated users to login
               redirect: '"/oauth2/start?rd=" + request.path'
-              # Extract user info from OAuth2 Proxy response headers
-              metadata:
-                githubUser: response.headers["x-auth-request-user"]
-                githubEmail: response.headers["x-auth-request-email"]
               addRequestHeaders:
                 x-forwarded-host: request.host
               includeResponseHeaders:
               - x-auth-request-user
+              - x-auth-request-email
+              # Extract user info from OAuth2 Proxy response headers
+              metadata:
+                oauthUser: response.headers["x-auth-request-user"]
+                oauthEmail: response.headers["x-auth-request-email"]
 ```
 
 The following table describes the key settings in the configuration.
 
 | Setting | Description |
 |---------|-------------|
-| `frontendPolicies.accessLog.add` | Logs the GitHub username and email from authenticated requests. |
+| `frontendPolicies.accessLog.add` | Logs the authenticated user's identity and email. |
 | `routes` (`oauth2-proxy`) | Routes `/oauth2/*` requests to OAuth2 Proxy for login and callback handling. |
 | `routes` (`application`) | The protected MCP endpoint with external authorization. |
+| `extAuthz.includeRequestHeaders` | Forwards the browser session cookie to OAuth2 Proxy. |
 | `extAuthz.host` | The OAuth2 Proxy address for authentication checks. |
 | `extAuthz.protocol.http.path` | The endpoint that OAuth2 Proxy uses to validate authentication. |
 | `extAuthz.protocol.http.redirect` | Where to send unauthenticated users. |
+| `extAuthz.protocol.http.includeResponseHeaders` | Copies OAuth2 Proxy identity headers into the backend request. |
 | `extAuthz.protocol.http.metadata` | Extracts user information from the OAuth2 Proxy response headers. |
 
 ## Step 5: Start agentgateway
@@ -168,51 +168,11 @@ agentgateway -f config.yaml
    1. Open [http://localhost:3000/mcp](http://localhost:3000/mcp).
    2. You are redirected to GitHub for authentication.
    3. After you log in, you are redirected back to the MCP endpoint.
-   4. The agentgateway logs show your GitHub username and email in the `github.user` and `github.email` access log fields.
+   4. The agentgateway logs show the authenticated user's identity and email in the `oauth.user` and `oauth.email` access log fields.
 
-## Use other OAuth providers {#other-providers}
+## Other providers
 
-OAuth2 Proxy supports many providers. To use a different provider, update the Docker command from [Step 3](#step-3-start-oauth2-proxy).
-
-{{< tabs items="Google,Azure AD" >}}
-{{% tab %}}
-```bash
-docker run -d --name oauth2-proxy \
-  -p 4180:4180 \
-  --add-host=host.docker.internal:host-gateway \
-  -e OAUTH2_PROXY_CLIENT_ID=$GOOGLE_CLIENT_ID \
-  -e OAUTH2_PROXY_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET \
-  -e OAUTH2_PROXY_COOKIE_SECRET=$OAUTH2_PROXY_COOKIE_SECRET \
-  -e OAUTH2_PROXY_COOKIE_SECURE=false \
-  quay.io/oauth2-proxy/oauth2-proxy:latest \
-  --provider=google \
-  --email-domain=* \
-  --upstream=file:///dev/null \
-  --http-address=0.0.0.0:4180 \
-  --set-xauthrequest \
-  --reverse-proxy=true
-```
-{{% /tab %}}
-{{% tab %}}
-```bash
-docker run -d --name oauth2-proxy \
-  -p 4180:4180 \
-  --add-host=host.docker.internal:host-gateway \
-  -e OAUTH2_PROXY_CLIENT_ID=$AZURE_CLIENT_ID \
-  -e OAUTH2_PROXY_CLIENT_SECRET=$AZURE_CLIENT_SECRET \
-  -e OAUTH2_PROXY_COOKIE_SECRET=$OAUTH2_PROXY_COOKIE_SECRET \
-  -e OAUTH2_PROXY_COOKIE_SECURE=false \
-  quay.io/oauth2-proxy/oauth2-proxy:latest \
-  --provider=azure \
-  --oidc-issuer-url=https://login.microsoftonline.com/$AZURE_TENANT_ID/v2.0 \
-  --email-domain=* \
-  --upstream=file:///dev/null \
-  --http-address=0.0.0.0:4180 \
-  --set-xauthrequest \
-  --reverse-proxy=true
-```
-{{% /tab %}}
-{{< /tabs >}}
+OAuth2 Proxy supports many providers. The agentgateway configuration stays the same, but you should follow the OAuth2 Proxy documentation for the provider-specific flags and callback settings.
 
 ## Production considerations
 

--- a/content/docs/standalone/latest/integrations/auth/okta.md
+++ b/content/docs/standalone/latest/integrations/auth/okta.md
@@ -40,8 +40,6 @@ binds:
         mcpAuthentication:
           mode: strict
           issuer: https://your-org.okta.com/oauth2/default
-          audiences:
-          - api://agentgateway
           jwks:
             url: https://your-org.okta.com/oauth2/default/v1/keys
           resourceMetadata:

--- a/content/docs/standalone/latest/integrations/auth/okta.md
+++ b/content/docs/standalone/latest/integrations/auth/okta.md
@@ -1,10 +1,10 @@
 ---
 title: Okta
 weight: 50
-description: Integrate agentgateway with Okta for enterprise identity management
+description: Use Okta access tokens with agentgateway
 ---
 
-[Okta](https://www.okta.com/) is an enterprise identity platform. agentgateway can validate JWTs issued by Okta for API authentication.
+[Okta](https://www.okta.com/) is an enterprise identity platform. agentgateway can validate access tokens issued by Okta with `mcpAuthentication`.
 
 ## Why use Okta with agentgateway?
 
@@ -12,11 +12,11 @@ description: Integrate agentgateway with Okta for enterprise identity management
 - **Directory integration** - Active Directory, LDAP sync
 - **Lifecycle management** - Automated provisioning/deprovisioning
 - **Compliance** - SOC 2, HIPAA, FedRAMP certified
-- **API Access Management** - OAuth2/OIDC for APIs
+- **API protection** - JWT-based token validation for MCP services
 
 ## Configuration
 
-Configure agentgateway to validate Okta JWTs:
+Configure agentgateway to validate Okta tokens and publish MCP protected-resource metadata:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -27,10 +27,15 @@ binds:
     - backends:
       - mcp:
           targets:
-          - name: my-server
+          - name: tools
             stdio:
               cmd: npx
               args: ["@modelcontextprotocol/server-everything"]
+      matches:
+      - path:
+          exact: /mcp
+      - path:
+          exact: /.well-known/oauth-protected-resource/mcp
       policies:
         mcpAuthentication:
           mode: strict
@@ -39,19 +44,25 @@ binds:
           - api://agentgateway
           jwks:
             url: https://your-org.okta.com/oauth2/default/v1/keys
+          resourceMetadata:
+            resource: https://gateway.example.com/mcp
+            scopesSupported:
+            - agentgateway
+            bearerMethodsSupported:
+            - header
 ```
 
 ## Okta setup
 
-1. Create an Authorization Server (or use `default`):
-   - Admin Console → Security → API → Authorization Servers
+1. Create an Authorization Server or use `default`:
+   - Admin Console > Security > API > Authorization Servers
 
 2. Add a custom scope:
    - Name: `agentgateway`
    - Description: Access to agentgateway
 
 3. Create an API Services application:
-   - Applications → Create App Integration
+   - Applications > Create App Integration
    - Sign-in method: API Services
    - Note the Client ID and Client Secret
 
@@ -68,25 +79,22 @@ curl -X POST "https://your-org.okta.com/oauth2/default/v1/token" \
   -d "scope=agentgateway"
 ```
 
-## Group-based authorization
+## Using the token
 
-Use Okta groups with agentgateway authorization:
-
-```yaml
-policies:
-  mcpAuthentication:
-    mode: strict
-    issuer: https://your-org.okta.com/oauth2/default
-    audiences: [api://agentgateway]
-    jwks:
-      url: https://your-org.okta.com/oauth2/default/v1/keys
-  authorization:
-    rules:
-    # Check for Okta group membership
-    - '"AI-Users" in jwt.groups'
+```bash
+curl http://localhost:3000/mcp \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize",...}'
 ```
+
+## Authorization
+
+Okta does not require a provider-specific authorization schema in agentgateway. If you need authorization, use the generic [HTTP authorization]({{< link-hextra path="/configuration/security/http-authz" >}}) or [MCP authorization]({{< link-hextra path="/mcp/mcp-authz" >}}) policies against claims that your Okta authorization server actually emits. Avoid copying group-claim rules unless you have confirmed the claim is present in your tokens.
 
 ## Learn more
 
 - [Okta Developer Documentation](https://developer.okta.com/)
 - [MCP authentication]({{< link-hextra path="/configuration/security/mcp-authn" >}})
+- [HTTP authorization]({{< link-hextra path="/configuration/security/http-authz" >}})
+- [MCP authorization]({{< link-hextra path="/mcp/mcp-authz" >}})

--- a/content/docs/standalone/latest/integrations/auth/tailscale.md
+++ b/content/docs/standalone/latest/integrations/auth/tailscale.md
@@ -1,25 +1,29 @@
 ---
 title: Tailscale
 weight: 30
-description: Authenticate users with their Tailscale identity for zero-trust access to your MCP servers.
+description: Use Tailscale as a network boundary in front of agentgateway.
 ---
 
-Agentgateway can integrate with [Tailscale](https://tailscale.com/) to authenticate users based on their Tailscale identity, which enables zero-trust access to your MCP servers. Agentgateway uses an [external authorization (`extAuthz`)]({{< link-hextra path="/configuration/security/external-authz" >}}) policy to call the local Tailscale daemon's `whois` API and identify the user behind each connection.
+You can use [Tailscale](https://tailscale.com/) with agentgateway to place your MCP servers behind a private network boundary (your tailnet).
+
+{{< callout type="warning" >}}
+agentgateway does not currently integrate with the Tailscale local API to resolve a request to a Tailscale *user* or *device* identity. Treat Tailscale as a network/access boundary, and use agentgateway policies (JWT/OIDC, HTTP authz, external authz) when you need application-layer authentication and authorization.
+{{< /callout >}}
 
 ## How it works
 
-1. The client connects from its Tailscale IP address (`100.x.x.x`).
-2. Agentgateway calls the Tailscale local `whois` API with the source IP address.
-3. Tailscale returns the node and user information.
-4. Agentgateway allows or denies the request and logs the identity.
+1. You run agentgateway on a host that is connected to your tailnet.
+2. Clients connect to agentgateway over Tailscale (using the host's tailnet IP or DNS name).
+3. Tailscale ACLs (and optionally agentgateway network authorization) restrict who can reach the gateway.
+4. agentgateway optionally applies application-layer policies (for example JWT validation) to authenticate/authorize requests.
 
 ## Before you begin
 
 - [Install agentgateway]({{< link-hextra path="/quickstart/" >}}).
-- [Install Tailscale](https://tailscale.com/download) and connect it to your tailnet.
-- Have another device on your tailnet to test from, or use the same machine through its Tailscale IP.
+- [Install Tailscale](https://tailscale.com/download) on the agentgateway host and connect it to your tailnet.
+- Have at least one other device on your tailnet to test from.
 
-## Step 1: Verify that Tailscale is running
+## Step 1: Verify Tailscale connectivity
 
 1. Check that Tailscale is connected. You should see your machine listed with a `100.x.x.x` IP address.
 
@@ -27,123 +31,46 @@ Agentgateway can integrate with [Tailscale](https://tailscale.com/) to authentic
    tailscale status
    ```
 
-2. Note your Tailscale IP address. You use this address to test access later.
+2. Note the host's Tailscale IP address. You use this address to test access later.
 
    ```bash
    tailscale ip -4
    ```
 
-## Step 2: Create the configuration
+## Step 2: Restrict access to your tailnet
 
-Create a `config.yaml` file. The configuration uses an `extAuthz` policy to call the Tailscale daemon's local `whois` API with the source IP address of each request, then extracts the node name and user email from the response. The socket path for the Tailscale daemon differs by platform.
+Use Tailscale ACLs/tags to control which users/devices in your tailnet can reach the agentgateway host and port. This is the recommended place to enforce tailnet identity-based access, because it happens before traffic reaches agentgateway.
 
-{{< tabs items="Linux,macOS" >}}
-{{% tab %}}
-```yaml
-# yaml-language-server: $schema=https://agentgateway.dev/schema/config
-frontendPolicies:
-  accessLog:
-    add:
-      tailscale.node: extauthz.tailscaleNode
-      tailscale.email: extauthz.tailscaleEmail
-
-binds:
-- port: 3000
-  listeners:
-  - name: default
-    protocol: HTTP
-    routes:
-    - name: application
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        cors:
-          allowOrigins: ["*"]
-          allowHeaders: ["*"]
-          exposeHeaders: ["Mcp-Session-Id"]
-        extAuthz:
-          host: unix:/run/tailscale/tailscaled.sock
-          protocol:
-            http:
-              path: |
-                "/localapi/v0/whois?addr=" + source.address
-              addRequestHeaders:
-                :authority: '"local-tailscaled.sock"'
-              metadata:
-                tailscaleNode: json(response.body).Node.Name
-                tailscaleEmail: json(response.body).UserProfile.LoginName
-```
-{{% /tab %}}
-{{% tab %}}
-```yaml
-# yaml-language-server: $schema=https://agentgateway.dev/schema/config
-frontendPolicies:
-  accessLog:
-    add:
-      tailscale.node: extauthz.tailscaleNode
-      tailscale.email: extauthz.tailscaleEmail
-
-binds:
-- port: 3000
-  listeners:
-  - name: default
-    protocol: HTTP
-    routes:
-    - name: application
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        cors:
-          allowOrigins: ["*"]
-          allowHeaders: ["*"]
-          exposeHeaders: ["Mcp-Session-Id"]
-        extAuthz:
-          host: unix:/var/run/tailscale/tailscaled.sock
-          protocol:
-            http:
-              path: |
-                "/localapi/v0/whois?addr=" + source.address
-              addRequestHeaders:
-                :authority: '"local-tailscaled.sock"'
-              metadata:
-                tailscaleNode: json(response.body).Node.Name
-                tailscaleEmail: json(response.body).UserProfile.LoginName
-```
-{{% /tab %}}
-{{< /tabs >}}
-
-The following table describes the key settings in the configuration.
-
-| Setting | Description |
-|---------|-------------|
-| `frontendPolicies.accessLog.add` | Adds the Tailscale identity to the access logs. |
-| `extAuthz.host` | The Unix socket path to the Tailscale daemon. |
-| `extAuthz.protocol.http.path` | A CEL expression that calls the Tailscale `whois` API with the client's source IP address. |
-| `addRequestHeaders.:authority` | The hostname that the Tailscale local API requires. |
-| `metadata.tailscaleNode` | Extracts the machine name from the Tailscale response. |
-| `metadata.tailscaleEmail` | Extracts the user email from the Tailscale response. |
-
-The value for `extAuthz.host` is the path to the Tailscale daemon's local socket, which differs by platform. Use the path that matches the platform where agentgateway runs.
-
-| Platform | Socket path |
-|----------|-------------|
-| Linux | `/run/tailscale/tailscaled.sock` |
-| macOS | `/var/run/tailscale/tailscaled.sock` |
-| Windows | Named pipe (not supported through a Unix socket) |
+If you also want agentgateway to enforce a network allowlist, configure a [network authorization policy]({{< link-hextra path="/configuration/security/network-authz/" >}}) to only accept connections from the Tailscale CGNAT range (`100.64.0.0/10`).
 
 {{< callout type="info" >}}
-On most Linux systems, `/var/run` is a symlink to `/run`, so `/var/run/tailscale/tailscaled.sock` and `/run/tailscale/tailscaled.sock` point to the same socket.
+This check is IP-based. It does not prove a specific Tailscale user/device identity, and it can be affected by routing (for example, subnet routers or proxies). Use Tailscale ACLs for identity-based control.
 {{< /callout >}}
+
+Create a `config.yaml` file:
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+frontendPolicies:
+  networkAuthorization:
+    rules:
+    - allow: 'cidr("100.64.0.0/10").containsIP(source.address)'
+
+binds:
+- port: 3000
+  listeners:
+  - name: default
+    protocol: HTTP
+    routes:
+    - name: mcp
+      backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]
+```
 
 ## Step 3: Start agentgateway
 
@@ -157,68 +84,34 @@ Example output:
 info proxy::gateway started bind bind="bind/3000"
 ```
 
-## Step 4: Test the authentication
+## Step 4: Test connectivity
 
-1. Send a request from localhost. Because localhost does not have a Tailscale identity, the request is denied with a `403 Forbidden` response.
-
-   ```bash
-   curl -i http://localhost:3000/mcp
-   ```
-
-   Example output:
-
-   ```
-   HTTP/1.1 403 Forbidden
-   external authorization failed
-   ```
-
-2. Send a request through your Tailscale IP address. The request passes authentication and reaches the MCP server, which returns a `406 Not Acceptable` response because the request does not include the required `text/event-stream` header.
+1. From a different device on your tailnet, send a request to the agentgateway host's Tailscale IP:
 
    ```bash
-   TAILSCALE_IP=$(tailscale ip -4)
-   curl -i http://$TAILSCALE_IP:3000/mcp
+   curl -i http://<TAILSCALE_IP>:3000/mcp
    ```
 
-   Example output:
+2. From a device that is not on your tailnet, verify that you cannot connect (either because of Tailscale ACLs or because the `networkAuthorization` policy rejects the connection).
 
-   ```
-   HTTP/1.1 406 Not Acceptable
-   Not Acceptable: Client must accept text/event-stream
-   ```
+## Next steps: add application-layer auth (optional)
 
-3. Send a complete MCP request through your Tailscale IP address with the required headers.
+Tailscale protects network access, but it does not replace HTTP/MCP authentication and authorization. Depending on your use case, you might also want to configure:
 
-   ```bash
-   TAILSCALE_IP=$(tailscale ip -4)
-   curl -X POST "http://$TAILSCALE_IP:3000/mcp" \
-     -H "Content-Type: application/json" \
-     -H "Accept: text/event-stream" \
-     -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
-   ```
-
-4. Check the agentgateway logs. After a successful request, the logs show the Tailscale identity from the access log fields that you configured.
-
-   ```
-   info request ... tailscale.node=your-machine-name tailscale.email=you@example.com
-   ```
+- [JWT authentication]({{< link-hextra path="/configuration/security/jwt-authn/" >}}) to validate OIDC access tokens.
+- [HTTP authorization]({{< link-hextra path="/configuration/security/http-authz/" >}}) for claim- and request-aware authorization rules.
+- [External authorization]({{< link-hextra path="/configuration/security/external-authz" >}}) to delegate authz decisions to an external service (such as an IdP-aware proxy).
 
 ## Troubleshooting
 
-**`external authorization failed` for Tailscale IPs**: Check that the Tailscale socket exists and is accessible at the path in your configuration.
+**Can't connect from a tailnet client**: Confirm that your client is connected to the same tailnet and that you are connecting to the agentgateway host's *Tailscale* IP/DNS name (not a LAN IP).
 
-```bash
-# Linux
-ls -la /run/tailscale/tailscaled.sock
-
-# macOS
-ls -la /var/run/tailscale/tailscaled.sock
-```
-
-**`no match for IP:port` in the Tailscale response**: The connecting IP address is not recognized by Tailscale. Make sure that you connect through a Tailscale IP address, not localhost or a LAN IP address.
+**Connection is rejected after enabling `networkAuthorization`**: Temporarily remove the `frontendPolicies.networkAuthorization` section to confirm whether the block is coming from Tailscale ACLs or from agentgateway. If you're using subnet routers, proxies, or other routing, the downstream `source.address` might not fall into `100.64.0.0/10`.
 
 ## Learn more
 
 {{< cards >}}
-  {{< card path="/configuration/security/external-authz" title="External authorization" subtitle="ExtAuthz configuration reference" >}}
+  {{< card path="/configuration/security/network-authz/" title="Network authorization" subtitle="L4 allow/deny rules for incoming connections" >}}
+  {{< card path="/configuration/security/jwt-authn/" title="JWT authentication" subtitle="Validate OIDC access tokens" >}}
   {{< card path="/configuration/security/" title="Security configuration" subtitle="Complete security options" >}}
 {{< /cards >}}


### PR DESCRIPTION
Refactor the auth integration docs into small, self-contained pages that only describe behaviors already documented in the canonical security reference.

Closes #2467