### PR TITLE
Remove Apple logo from Contributing Companies section

### DIFF
--- a/layouts/partials/homepage-content.html
+++ b/layouts/partials/homepage-content.html
@@ -894,7 +894,6 @@
       <div class="hp-logo-item"><img src="/aaif-light.svg" alt="AAIF" class="hp-logo-img"><span>AAIF</span></div>
       <div class="hp-logo-item"><img src="/adopters/solo-io-light.png" alt="Solo.io" class="hp-logo-img"><span>Solo.io</span></div>
       <div class="hp-logo-item"><img src="/quotes/microsoft.svg" alt="Microsoft" class="hp-logo-img"><span>Microsoft</span></div>
-      <div class="hp-logo-item"><img src="/logos/apple.svg" alt="Apple" class="hp-logo-img"><span>Apple</span></div>
       <div class="hp-logo-item"><img src="/logos/alibaba.svg" alt="Alibaba" class="hp-logo-img"><span>Alibaba</span></div>
       <div class="hp-logo-item"><img src="/logos/adobe.svg" alt="Adobe" class="hp-logo-img"><span>Adobe</span></div>
       <div class="hp-logo-item"><img src="/logos/aws.svg" alt="AWS" class="hp-logo-img"><span>AWS</span></div>
@@ -905,7 +904,6 @@
       <div class="hp-logo-item" aria-hidden="true"><img src="/aaif-light.svg" alt="AAIF" class="hp-logo-img"><span>AAIF</span></div>
       <div class="hp-logo-item" aria-hidden="true"><img src="/adopters/solo-io-light.png" alt="Solo.io" class="hp-logo-img"><span>Solo.io</span></div>
       <div class="hp-logo-item" aria-hidden="true"><img src="/quotes/microsoft.svg" alt="Microsoft" class="hp-logo-img"><span>Microsoft</span></div>
-      <div class="hp-logo-item" aria-hidden="true"><img src="/logos/apple.svg" alt="Apple" class="hp-logo-img"><span>Apple</span></div>
       <div class="hp-logo-item" aria-hidden="true"><img src="/logos/alibaba.svg" alt="Alibaba" class="hp-logo-img"><span>Alibaba</span></div>
       <div class="hp-logo-item" aria-hidden="true"><img src="/logos/adobe.svg" alt="Adobe" class="hp-logo-img"><span>Adobe</span></div>
       <div class="hp-logo-item" aria-hidden="true"><img src="/logos/aws.svg" alt="AWS" class="hp-logo-img"><span>AWS</span></div>


### PR DESCRIPTION
## Summary
Removes the Apple logo from the "Contributing Companies" logo marquee on the homepage (`layouts/partials/homepage-content.html`).

The logo appeared twice — once in the visible set and once in the `aria-hidden` duplicate that the scrolling animation uses to loop seamlessly. Both were removed to keep the marquee balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)