### PR TITLE
Part 2 examples updates

### DIFF
--- a/assets/agw-docs/standalone/quickstart/non-agentic-http.md
+++ b/assets/agw-docs/standalone/quickstart/non-agentic-http.md
@@ -201,5 +201,3 @@ docker stop httpbin
 ```
 
 {{% /steps %}}
-
-For a routing configuration that matches requests by path and method, see the [traffic-http example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-http/README.md).

--- a/assets/agw-docs/standalone/quickstart/non-agentic-http.md
+++ b/assets/agw-docs/standalone/quickstart/non-agentic-http.md
@@ -201,3 +201,5 @@ docker stop httpbin
 ```
 
 {{% /steps %}}
+
+For a routing configuration that matches requests by path and method, see the [traffic-http example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-http/README.md).

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -223,6 +223,17 @@ h6 {
     color: #9ca3af !important;
 }
 
+/* docs-theme-extras v0.1.14 shifted the centralized .sidebar-nav-wrapper top
+   padding from 0 to 1rem so the first sidebar item lines up with the module's
+   own hx:pt-6 (1.5rem) content pane. Agw's docs templates use a tighter hx:pt-2
+   (0.5rem) content pane, so that 1rem now pushes the first sidebar link ~1rem
+   below the first line of content. Restore the 0 top padding (the more-specific
+   selector wins over the module's .sidebar-nav-wrapper) to keep them aligned;
+   the right/bottom padding still comes from the module shorthand. */
+aside.sidebar-container > .sidebar-nav-wrapper {
+    padding-top: 0;
+}
+
 /* Hextra tabs - data-state show/hide and active styling */
 .hextra-tabs-panel {
     display: none;

--- a/content/docs/standalone/1.2.x/agent/a2a.md
+++ b/content/docs/standalone/1.2.x/agent/a2a.md
@@ -22,7 +22,7 @@ Create an agentgateway that proxies requests to the ADK agent that you create la
    * **Backend**: The agentgateway targets a backend on your localhost port 9999, which you create in a subsequent step.
    ```yaml
    cat <<EOF > config.yaml
-   {{< github url="https://agentgateway.dev/examples/a2a/config.yaml" >}}
+   {{< github url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/a2a/config.yaml" >}}
    EOF
    ```
 

--- a/content/docs/standalone/1.2.x/configuration/overview.md
+++ b/content/docs/standalone/1.2.x/configuration/overview.md
@@ -21,7 +21,7 @@ Agentgateway configuration has a few top level sections:
 ### Example configuration file {#example-file}
 
 ```yaml
-{{% github url="https://agentgateway.dev/examples/basic/config.yaml" %}}
+{{% github url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/basic/config.yaml" %}}
 ```
 
 ## Update configuration {#add}

--- a/content/docs/standalone/1.2.x/deployment/docker/_index.md
+++ b/content/docs/standalone/1.2.x/deployment/docker/_index.md
@@ -7,7 +7,7 @@ description: Overview of how to deploy agentgateway with Docker.
 To run agentgateway as a Docker container, agentgateway publishes official Docker images at `cr.agentgateway.dev/agentgateway`.
 
 Before you begin, create a [configuration file]({{< link-hextra path="/configuration/" >}}) for agentgateway. In this example, `config.yaml` is used.
-You might start with [this simple example configuration file](https://agentgateway.dev/examples/basic/config.yaml).
+You might start with [this simple example configuration file](https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/basic/config.yaml).
 
 ## Docker
 

--- a/content/docs/standalone/1.2.x/inference/_index.md
+++ b/content/docs/standalone/1.2.x/inference/_index.md
@@ -71,7 +71,7 @@ binds:
             destinationMode: passthrough
 ```
 
-For more examples, see the [standalone EPP example](https://github.com/agentgateway/agentgateway/blob/main/examples/standalone-epp/README.md).
+For more examples, see the [standalone EPP example](https://github.com/agentgateway/agentgateway/blob/v1.2.1/examples/standalone-epp/README.md).
 
 {{< cards>}}
   {{< card link="https://gateway-api-inference-extension.sigs.k8s.io/guides/standalone/#deploy-as-a-standalone-request-scheduler" title="Deploy a standalone request scheduler" icon="external-link" >}}

--- a/content/docs/standalone/1.2.x/integrations/mcp-servers/stdio.md
+++ b/content/docs/standalone/1.2.x/integrations/mcp-servers/stdio.md
@@ -17,7 +17,7 @@ stdio transport is ideal when:
 
 ```bash
 # Download the stdio MCP configuration
-curl -L https://agentgateway.dev/examples/basic/config.yaml -o config.yaml
+curl -L https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/basic/config.yaml -o config.yaml
 
 # Run agentgateway
 agentgateway -f config.yaml

--- a/content/docs/standalone/1.2.x/mcp/connect/openapi.md
+++ b/content/docs/standalone/1.2.x/mcp/connect/openapi.md
@@ -93,7 +93,7 @@ Build the Docker image from the source code. The example builds the image for an
 
 2. Download an OpenAPI configuration for your agentgateway.
    ```sh
-   curl -L https://agentgateway.dev/examples/openapi/config.yaml -o config.yaml
+   curl -L https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/openapi/config.yaml -o config.yaml
    ```
 
 3. Update the agentgateway configuration file as follows:

--- a/content/docs/standalone/1.2.x/mcp/connect/stdio.md
+++ b/content/docs/standalone/1.2.x/mcp/connect/stdio.md
@@ -15,7 +15,7 @@ An MCP backend allows exposing MCP servers through the agentgateway using {{< gl
 1. Download an MCP configuration for your agentgateway.
 
    ```yaml
-   curl -L https://agentgateway.dev/examples/basic/config.yaml -o config.yaml
+   curl -L https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/basic/config.yaml -o config.yaml
    ```
 
 2. Review the configuration file. 
@@ -24,7 +24,7 @@ An MCP backend allows exposing MCP servers through the agentgateway using {{< gl
    cat config.yaml
    ```
 
-   {{% github-yaml  url="https://agentgateway.dev/examples/basic/config.yaml" %}}
+   {{% github-yaml  url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/basic/config.yaml" %}}
 
    {{< reuse "agw-docs/snippets/review-table.md" >}}
 

--- a/content/docs/standalone/1.2.x/mcp/connect/virtual.md
+++ b/content/docs/standalone/1.2.x/mcp/connect/virtual.md
@@ -60,7 +60,7 @@ routes:
 1. Download a multiplex configuration for your agentgateway.
 
    ```yaml
-   curl -L https://agentgateway.dev/examples/multiplex/config.yaml -o config.yaml
+   curl -L https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/multiplex/config.yaml -o config.yaml
    ```
 
 2. Review the configuration file. 
@@ -69,7 +69,7 @@ routes:
    cat config.yaml
    ```
 
-   {{% github-yaml url="https://agentgateway.dev/examples/multiplex/config.yaml" %}}
+   {{% github-yaml url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v1.2.1/examples/multiplex/config.yaml" %}}
 
    * **Listener**: An HTTP listener is configured and bound on port 3000. It includes a basic route that matches all traffic to an MCP backend.
    * **Backend**: The MCP backend defines two **targets**: `time` and `everything`. Note that the target names cannot include underscores (`_`). These targets are multiplexed together and exposed as a single unified MCP server to clients. All tools from both targets are available, prefixed with their target name.

--- a/content/docs/standalone/latest/configuration/listeners.md
+++ b/content/docs/standalone/latest/configuration/listeners.md
@@ -57,6 +57,8 @@ listeners:
     key: examples/tls/certs/key-wildcard.pem
 ```
 
+For a complete HTTPS listener configuration, see the [mcp-tls example](https://github.com/agentgateway/agentgateway/blob/main/examples/mcp-tls/README.md).
+
 ### Redirect HTTP to HTTPS
 
 To serve both HTTP and HTTPS, configure an HTTP listener that redirects all traffic to the HTTPS listener with a `requestRedirect` policy. The following example listens for plaintext HTTP on port 80 and redirects it to HTTPS, while serving encrypted traffic on port 443.

--- a/content/docs/standalone/latest/configuration/resiliency/rate-limits.md
+++ b/content/docs/standalone/latest/configuration/resiliency/rate-limits.md
@@ -96,6 +96,8 @@ localRateLimit:
 > [!NOTE]
 > The term "tokens" is used for two distinct meanings. In `maxTokens` and `tokensPerFill`, it indicates the "token" in the token bucket counter. Each token can allow either 1 LLM token, or 1 HTTP request, based on the `type`.
 
+For a runnable local rate limiting configuration, see the [traffic-ratelimiting-local example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-ratelimiting-local/README.md).
+
 ### Remote
 
 Remote rate limits are not defined directly in agentgateway.
@@ -181,6 +183,8 @@ remoteRateLimit:
 | `policies.backendTLS` | TLS settings for the connection to the rate limit service. Use `root` to specify a CA cert, `insecure: true` to skip certificate verification (not recommended for production). |
 | `policies.tcp.connectTimeout` | Connection timeout specified as `secs` and `nanos`. |
 | `policies.http.requestTimeout` | Request-level timeout as a duration string (for example, `"5s"`). Use for HTTP-based rate limit service connections. |
+
+For a complete remote rate limiting setup that uses the Envoy rate limit service with Redis, see the [traffic-ratelimiting-global example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-ratelimiting-global/README.md).
 
 ## Conditional execution
 

--- a/content/docs/standalone/latest/configuration/security/external-authz.md
+++ b/content/docs/standalone/latest/configuration/security/external-authz.md
@@ -154,6 +154,8 @@ binds:
               grpc: {}
 ```
 
+For a runnable configuration that fetches upstream OAuth tokens from Keycloak by using token exchange and client-credentials grants, see the [traffic-backend-oauth example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-backend-oauth/README.md).
+
 ## Conditional execution
 
 To choose between multiple external authorization servers based on the request, use the `conditional` field. For example, you can send admin paths to a stricter authorization server and route every other request to a standard one. For details, see [Conditional policies]({{< link-hextra path="/configuration/policies/conditional-policies" >}}).

--- a/content/docs/standalone/latest/configuration/security/mcp-authn.md
+++ b/content/docs/standalone/latest/configuration/security/mcp-authn.md
@@ -126,3 +126,5 @@ policies:
 ## Passthrough
 
 When the MCP server already implements OAuth authentication, no additional configuration is needed. Agentgateway passes requests through without modification.
+
+For runnable configurations that cover spec-compliant, remote, and vendor-specific authorization servers, see the [mcp-authentication example](https://github.com/agentgateway/agentgateway/blob/main/examples/mcp-authentication/README.md).

--- a/content/docs/standalone/latest/configuration/security/mcp-authz.md
+++ b/content/docs/standalone/latest/configuration/security/mcp-authz.md
@@ -59,3 +59,5 @@ mcpAuthorization:
 ```
 
 Refer to the [CEL reference]({{< link-hextra path="/configuration/traffic-management/transformations" >}}) for additional variables.
+
+For a runnable configuration that pairs JWT authentication with CEL tool-authorization rules, see the [mcp-authorization example](https://github.com/agentgateway/agentgateway/blob/main/examples/mcp-authorization/README.md).

--- a/content/docs/standalone/latest/configuration/security/oidc.md
+++ b/content/docs/standalone/latest/configuration/security/oidc.md
@@ -128,3 +128,4 @@ frontendPolicies:
 - [Keycloak integration]({{< link-hextra path="/integrations/auth/keycloak" >}})
 - [Auth0 integration]({{< link-hextra path="/integrations/auth/auth0" >}})
 - [MCP authentication]({{< link-hextra path="/configuration/security/mcp-authn" >}}) for MCP-specific OAuth flows
+- [traffic-oidc example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-oidc/README.md) for a runnable browser OIDC login flow with Keycloak

--- a/content/docs/standalone/latest/configuration/traffic-management/matching.md
+++ b/content/docs/standalone/latest/configuration/traffic-management/matching.md
@@ -267,6 +267,8 @@ routes:
     - host: api.example.com:8080
 ```
 
+For a complete, runnable configuration that matches requests by path and method, see the [traffic-http example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-http/README.md).
+
 ## TCP routes
 
 For routes configured with [TCP listeners]({{< link-hextra path="/configuration/routes#tcp-routes" >}}), you can configure the following matching conditions.

--- a/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
+++ b/content/docs/standalone/latest/integrations/auth/oauth2-proxy.md
@@ -237,4 +237,5 @@ cd .. && rm -rf oauth2-proxy-test
 {{< cards >}}
   {{< card path="/configuration/security/external-authz" title="External authorization" subtitle="ExtAuthz configuration reference" >}}
   {{< card path="/configuration/security/" title="Security configuration" subtitle="Complete security options" >}}
+  {{< card link="https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-oauth2-proxy/README.md" title="OAuth2 Proxy example" subtitle="Runnable GitHub OAuth configuration" icon="external-link" >}}
 {{< /cards >}}

--- a/content/docs/standalone/latest/integrations/auth/tailscale.md
+++ b/content/docs/standalone/latest/integrations/auth/tailscale.md
@@ -221,4 +221,5 @@ ls -la /var/run/tailscale/tailscaled.sock
 {{< cards >}}
   {{< card path="/configuration/security/external-authz" title="External authorization" subtitle="ExtAuthz configuration reference" >}}
   {{< card path="/configuration/security/" title="Security configuration" subtitle="Complete security options" >}}
+  {{< card link="https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-tailscale-auth/README.md" title="Tailscale auth example" subtitle="Runnable whois-based identity configuration" icon="external-link" >}}
 {{< /cards >}}

--- a/content/docs/standalone/latest/llm/about.md
+++ b/content/docs/standalone/latest/llm/about.md
@@ -199,6 +199,8 @@ llm:
 
 Clients send `"model": "fast"` or `"model": "smart"`, and agentgateway translates these to the corresponding provider models.
 
+For a complete example that routes model names to different providers, see the [llm-basic example](https://github.com/agentgateway/agentgateway/blob/main/examples/llm-basic/README.md).
+
 ### Route priority
 
 When multiple models match a request, the more precise match takes precedence.

--- a/content/docs/standalone/latest/llm/observability.md
+++ b/content/docs/standalone/latest/llm/observability.md
@@ -79,6 +79,8 @@ For catalog configuration and the full list of cost fields, see [Model costs]({{
 5. Open the [Jaeger UI](http://localhost:16686/search) and verify that you can see traces for your LLM request. 
    
 
+For a complete OpenTelemetry tracing configuration that you can export to Jaeger or Langfuse, see the [llm-telemetry example](https://github.com/agentgateway/agentgateway/blob/main/examples/llm-telemetry/README.md).
+
 ## View logs
 
 Agentgateway automatically logs information to stdout. When you run agentgateway on your local machine, you can view a log entry for each request that is sent to agentgateway in your CLI output. 

--- a/content/docs/standalone/latest/llm/prompt-guards/regex.md
+++ b/content/docs/standalone/latest/llm/prompt-guards/regex.md
@@ -195,6 +195,8 @@ The following example rejects requests that contain PII data, such as Social Sec
    }
    ```
 
+For a runnable configuration that combines regex rejection with webhook moderation, see the [llm-prompt-guard example](https://github.com/agentgateway/agentgateway/blob/main/examples/llm-prompt-guard/README.md).
+
 ## Mask PII in responses
 
 You can also filter LLM responses to redact sensitive data before it reaches the client. When a match is found, agentgateway replaces built-in pattern matches with `<ENTITY_TYPE>` (for example, `<CREDIT_CARD>`) and custom pattern matches with `<masked>`. The following example masks credit card numbers in responses.

--- a/content/docs/standalone/main/configuration/listeners.md
+++ b/content/docs/standalone/main/configuration/listeners.md
@@ -155,6 +155,8 @@ EOF
 agentgateway -f config3.yaml --validate-only
 {{< /doc-test >}}
 
+For a complete HTTPS listener configuration, see the [mcp-tls example](https://github.com/agentgateway/agentgateway/blob/main/examples/mcp-tls/README.md).
+
 ### Redirect HTTP to HTTPS
 
 To serve both HTTP and HTTPS, configure an HTTP listener that redirects all traffic to the HTTPS listener with a `requestRedirect` policy. The following example listens for plaintext HTTP on port 80 and redirects it to HTTPS, while serving encrypted traffic on port 443.

--- a/content/docs/standalone/main/configuration/resiliency/rate-limits.md
+++ b/content/docs/standalone/main/configuration/resiliency/rate-limits.md
@@ -349,6 +349,8 @@ agentgateway -f config2-mcp.yaml --validate-only
 > [!NOTE]
 > The term "tokens" is used for two distinct meanings. In `maxTokens` and `tokensPerFill`, it indicates the "token" in the token bucket counter. Each token can allow either 1 LLM token, or 1 HTTP request, based on the `type`.
 
+For a runnable local rate limiting configuration, see the [traffic-ratelimiting-local example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-ratelimiting-local/README.md).
+
 ### Remote
 
 Remote rate limits are not defined directly in agentgateway.
@@ -594,6 +596,8 @@ remoteRateLimit:
 | `policies.backendTLS` | TLS settings for the connection to the rate limit service. Use `root` to specify a CA cert, `insecure: true` to skip certificate verification (not recommended for production). |
 | `policies.tcp.connectTimeout` | Connection timeout specified as `secs` and `nanos`. |
 | `policies.http.requestTimeout` | Request-level timeout as a duration string (for example, `"5s"`). Use for HTTP-based rate limit service connections. |
+
+For a complete remote rate limiting setup that uses the Envoy rate limit service with Redis, see the [traffic-ratelimiting-global example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-ratelimiting-global/README.md).
 
 ## Conditional execution
 

--- a/content/docs/standalone/main/configuration/security/external-authz.md
+++ b/content/docs/standalone/main/configuration/security/external-authz.md
@@ -310,6 +310,8 @@ EOF
 agentgateway -f config2.yaml --validate-only
 {{< /doc-test >}}
 
+For a runnable configuration that fetches upstream OAuth tokens from Keycloak by using token exchange and client-credentials grants, see the [traffic-backend-oauth example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-backend-oauth/README.md).
+
 ## Conditional execution
 
 To choose between multiple external authorization servers based on the request, use the `conditional` field. For example, you can send admin paths to a stricter authorization server and route every other request to a standard one. For details, see [Conditional policies]({{< link-hextra path="/configuration/policies/conditional-policies" >}}).

--- a/content/docs/standalone/main/configuration/security/mcp-authn.md
+++ b/content/docs/standalone/main/configuration/security/mcp-authn.md
@@ -379,3 +379,5 @@ policies:
 ## Passthrough
 
 When the MCP server already implements OAuth authentication, no additional configuration is needed. Agentgateway passes requests through without modification.
+
+For runnable configurations that cover spec-compliant, remote, and vendor-specific authorization servers, see the [mcp-authentication example](https://github.com/agentgateway/agentgateway/blob/main/examples/mcp-authentication/README.md).

--- a/content/docs/standalone/main/configuration/security/mcp-authz.md
+++ b/content/docs/standalone/main/configuration/security/mcp-authz.md
@@ -189,3 +189,5 @@ mcpAuthorization:
 ```
 
 Refer to the [CEL reference]({{< link-hextra path="/reference/cel/" >}}) for additional variables.
+
+For a runnable configuration that pairs JWT authentication with CEL tool-authorization rules, see the [mcp-authorization example](https://github.com/agentgateway/agentgateway/blob/main/examples/mcp-authorization/README.md).

--- a/content/docs/standalone/main/configuration/security/oidc.md
+++ b/content/docs/standalone/main/configuration/security/oidc.md
@@ -230,3 +230,4 @@ frontendPolicies:
 - [Keycloak integration]({{< link-hextra path="/integrations/auth/keycloak" >}})
 - [Auth0 integration]({{< link-hextra path="/integrations/auth/auth0" >}})
 - [MCP authentication]({{< link-hextra path="/configuration/security/mcp-authn" >}}) for MCP-specific OAuth flows
+- [traffic-oidc example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-oidc/README.md) for a runnable browser OIDC login flow with Keycloak

--- a/content/docs/standalone/main/configuration/traffic-management/matching.md
+++ b/content/docs/standalone/main/configuration/traffic-management/matching.md
@@ -362,6 +362,8 @@ EOF
 agentgateway -f config.yaml --validate-only
 {{< /doc-test >}}
 
+For a complete, runnable configuration that matches requests by path and method, see the [traffic-http example](https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-http/README.md).
+
 ## TCP routes
 
 For routes configured with [TCP listeners]({{< link-hextra path="/configuration/routes#tcp-routes" >}}), you can configure the following matching conditions.

--- a/content/docs/standalone/main/integrations/auth/oauth2-proxy.md
+++ b/content/docs/standalone/main/integrations/auth/oauth2-proxy.md
@@ -237,4 +237,5 @@ cd .. && rm -rf oauth2-proxy-test
 {{< cards >}}
   {{< card path="/configuration/security/external-authz" title="External authorization" subtitle="ExtAuthz configuration reference" >}}
   {{< card path="/configuration/security/" title="Security configuration" subtitle="Complete security options" >}}
+  {{< card link="https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-oauth2-proxy/README.md" title="OAuth2 Proxy example" subtitle="Runnable GitHub OAuth configuration" icon="external-link" >}}
 {{< /cards >}}

--- a/content/docs/standalone/main/integrations/auth/tailscale.md
+++ b/content/docs/standalone/main/integrations/auth/tailscale.md
@@ -221,4 +221,5 @@ ls -la /var/run/tailscale/tailscaled.sock
 {{< cards >}}
   {{< card path="/configuration/security/external-authz" title="External authorization" subtitle="ExtAuthz configuration reference" >}}
   {{< card path="/configuration/security/" title="Security configuration" subtitle="Complete security options" >}}
+  {{< card link="https://github.com/agentgateway/agentgateway/blob/main/examples/traffic-tailscale-auth/README.md" title="Tailscale auth example" subtitle="Runnable whois-based identity configuration" icon="external-link" >}}
 {{< /cards >}}

--- a/content/docs/standalone/main/llm/about.md
+++ b/content/docs/standalone/main/llm/about.md
@@ -199,6 +199,8 @@ llm:
 
 Clients send `"model": "fast"` or `"model": "smart"`, and agentgateway translates these to the corresponding provider models.
 
+For a complete example that routes model names to different providers, see the [llm-basic example](https://github.com/agentgateway/agentgateway/blob/main/examples/llm-basic/README.md).
+
 ### Route priority
 
 When multiple models match a request, the more precise match takes precedence.

--- a/content/docs/standalone/main/llm/observability.md
+++ b/content/docs/standalone/main/llm/observability.md
@@ -79,6 +79,8 @@ For catalog configuration and the full list of cost fields, see [Model costs]({{
 5. Open the [Jaeger UI](http://localhost:16686/search) and verify that you can see traces for your LLM request. 
    
 
+For a complete OpenTelemetry tracing configuration that you can export to Jaeger or Langfuse, see the [llm-telemetry example](https://github.com/agentgateway/agentgateway/blob/main/examples/llm-telemetry/README.md).
+
 ## View logs
 
 Agentgateway automatically logs information to stdout. When you run agentgateway on your local machine, you can view a log entry for each request that is sent to agentgateway in your CLI output. 

--- a/content/docs/standalone/main/llm/prompt-guards/regex.md
+++ b/content/docs/standalone/main/llm/prompt-guards/regex.md
@@ -195,6 +195,8 @@ The following example rejects requests that contain PII data, such as Social Sec
    }
    ```
 
+For a runnable configuration that combines regex rejection with webhook moderation, see the [llm-prompt-guard example](https://github.com/agentgateway/agentgateway/blob/main/examples/llm-prompt-guard/README.md).
+
 ## Mask PII in responses
 
 You can also filter LLM responses to redact sensitive data before it reaches the client. When a match is found, agentgateway replaces built-in pattern matches with `<ENTITY_TYPE>` (for example, `<CREDIT_CARD>`) and custom pattern matches with `<masked>`. The following example masks credit card numbers in responses.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/agentgateway/website
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.1.13 // indirect
+require github.com/solo-io/docs-theme-extras v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.1.13 h1:b9y3wSsuCtr+esOH1tx2mGR0qFz1E7LA1VDJHmLysoA=
 github.com/solo-io/docs-theme-extras v0.1.13/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.1.14 h1:oSCd3efUIuSKb1cXl+qeLN3pjU3sj+tkegptF6u6gnk=
+github.com/solo-io/docs-theme-extras v0.1.14/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=


### PR DESCRIPTION
Adds links to examples files. Also updated the theme version and made a small padding adjustment.

Did not add to these topics:

- llm-prompt-enrichment → llm/transformations.md is about CEL field transforms, a different mechanism. Weak fit.
- traffic-aws-agentcore → integrations/platforms/aws.md is deploy-on-AWS, not proxy-to-AgentCore. Weak fit.
- traffic-identity-assertion → no page covers OAuth on-behalf-of token exchange. Needs a new section.