### PR TITLE
Adjusted doc tests to pull last good nightly build on failure

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -155,7 +155,9 @@ jobs:
               # Capture the log first, then extract, so an early-exiting pipe (SIGPIPE under
               # `set -o pipefail`) can't fail the step.
               LOG=$(gh run view "$rid" --repo "$UPSTREAM" --log 2>/dev/null) || LOG=""
-              VER=$(printf '%s\n' "$LOG" | grep -oiE '0\.0\.0-alpha\.[0-9a-f]+' | head -n1) || VER=""
+              # here-string + `grep -m1` avoids a pipe, so grep can't be killed by SIGPIPE
+              # (which would fail the step under `set -o pipefail`); `|| true` covers no-match.
+              VER=$(grep -m1 -oiE '0\.0\.0-alpha\.[0-9a-f]+' <<<"$LOG" || true)
               [ -n "$VER" ] || continue
               if installable "$VER"; then
                 RESOLVED="$VER"

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}
       has_tests: ${{ steps.list.outputs.has_tests }}
+      dev_version: ${{ steps.dev-version.outputs.dev_version }}
     steps:
       - name: Checkout website repo
         uses: actions/checkout@v6
@@ -95,6 +96,79 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
 
+      # Resolve an installable version for the development ("main"/experimental) install
+      # snippets. Those pages install the nightly chart pinned in
+      # assets/agw-docs/versions/patch-dev.md (normally the floating `0.0.0-latest-dev`).
+      #
+      # A failed upstream nightly (agentgateway/agentgateway) still publishes the
+      # `0.0.0-latest-dev` chart, but with an `appVersion` pointing at a proxy image whose
+      # build/push was skipped, so the image never lands in the registry. The deployer then
+      # tries to pull a `v0.0.0-alpha.<sha>` image that does not exist -> ImagePullBackOff ->
+      # every dev-channel doc test times out.
+      #
+      # We can do nothing to fix an upstream nightly, so instead of going red we resolve the
+      # newest *fully published* build: keep `0.0.0-latest-dev` when its chart's image
+      # actually exists, otherwise fall back to the most recent successful nightly's immutable
+      # `0.0.0-alpha.<sha>` chart (which has both a chart and a matching image). Any failure in
+      # this step falls back to the documented default, i.e. today's behavior.
+      - name: Resolve installable dev build version
+        id: dev-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          REG=cr.agentgateway.dev
+          CHART="oci://${REG}/charts/agentgateway"
+          IMG="${REG}/agentgateway"
+          UPSTREAM=agentgateway/agentgateway
+          DEFAULT=$(cat assets/agw-docs/versions/patch-dev.md)
+          RESOLVED="$DEFAULT"
+
+          # True if the container image tag exists in the registry (anonymous, public).
+          img_exists() { docker buildx imagetools inspect "${IMG}:$1" >/dev/null 2>&1; }
+
+          # Echo a chart version's appVersion, or nothing if the chart tag does not exist.
+          chart_appversion() {
+            helm show chart "$CHART" --version "$1" 2>/dev/null \
+              | awk -F': *' '/^appVersion:/ { gsub(/"/,"",$2); print $2; exit }'
+          }
+
+          # True if a chart version exists AND the proxy image its appVersion resolves to
+          # exists. The deployer prefixes the appVersion with `v` when it is absent.
+          installable() {
+            local av; av=$(chart_appversion "$1")
+            [ -n "$av" ] || return 1
+            case "$av" in
+              v*) img_exists "$av" ;;
+              *)  img_exists "v$av" || img_exists "$av" ;;
+            esac
+          }
+
+          if installable "$DEFAULT"; then
+            echo "Default dev build '$DEFAULT' is installable; using it."
+          else
+            echo "Default dev build '$DEFAULT' is not installable (broken upstream nightly?); searching last successful nightly."
+            RUN_IDS=$(gh run list --repo "$UPSTREAM" --workflow nightly.yml \
+              --status success --limit 15 --json databaseId --jq '.[].databaseId' 2>/dev/null || true)
+            for rid in $RUN_IDS; do
+              # The nightly records its version as `Nightly version: 0.0.0-alpha.<sha>` in the log.
+              VER=$(gh run view "$rid" --repo "$UPSTREAM" --log 2>/dev/null \
+                | grep -oE '0\.0\.0-alpha\.[0-9a-fA-F]+' | head -1)
+              [ -n "$VER" ] || continue
+              if installable "$VER"; then
+                RESOLVED="$VER"
+                echo "Falling back to last good nightly build '$VER' (run $rid)."
+                break
+              fi
+            done
+            if [ "$RESOLVED" = "$DEFAULT" ]; then
+              echo "No installable fallback found; leaving default '$DEFAULT' in place."
+            fi
+          fi
+
+          echo "dev_version=$RESOLVED" >> "$GITHUB_OUTPUT"
+          echo "Resolved dev build version: $RESOLVED"
+
   run-test:
     name: "${{ matrix.shard_name }}"
     needs: discover
@@ -133,6 +207,15 @@ jobs:
 
       - name: Install yamltest
         run: npm install -g yamltest@latest
+
+      # Redirect the development install snippets to the version resolved in `discover`.
+      # Only rewrites the checkout used by this run; the committed docs still ship
+      # `0.0.0-latest-dev`. No-op when the default is already installable.
+      - name: Pin dev build version
+        if: needs.discover.outputs.dev_version != '' && needs.discover.outputs.dev_version != '0.0.0-latest-dev'
+        run: |
+          printf '%s' '${{ needs.discover.outputs.dev_version }}' > assets/agw-docs/versions/patch-dev.md
+          echo "Pinned assets/agw-docs/versions/patch-dev.md to ${{ needs.discover.outputs.dev_version }} for this run."
 
       - name: Run doc tests
         env:

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -152,8 +152,10 @@ jobs:
               --status success --limit 15 --json databaseId --jq '.[].databaseId' 2>/dev/null || true)
             for rid in $RUN_IDS; do
               # The nightly records its version as `Nightly version: 0.0.0-alpha.<sha>` in the log.
-              VER=$(gh run view "$rid" --repo "$UPSTREAM" --log 2>/dev/null \
-                | grep -oE '0\.0\.0-alpha\.[0-9a-fA-F]+' | head -1)
+              # Capture the log first, then extract, so an early-exiting pipe (SIGPIPE under
+              # `set -o pipefail`) can't fail the step.
+              LOG=$(gh run view "$rid" --repo "$UPSTREAM" --log 2>/dev/null) || LOG=""
+              VER=$(printf '%s\n' "$LOG" | grep -oiE '0\.0\.0-alpha\.[0-9a-f]+' | head -n1) || VER=""
               [ -n "$VER" ] || continue
               if installable "$VER"; then
                 RESOLVED="$VER"


### PR DESCRIPTION
## What this does

Makes the doc-test suite resilient to broken upstream nightly builds of agentgateway.

The development/experimental install pages install the nightly chart pinned in `assets/agw-docs/versions/patch-dev.md` (the floating `0.0.0-latest-dev`). When an upstream nightly (`agentgateway/agentgateway`) fails partway, it still publishes the `0.0.0-latest-dev` **chart**, but with an `appVersion` pointing at a proxy **image** whose build/push was skipped. The deployer then tries to pull a `v0.0.0-alpha.<sha>` image that never landed in the registry → `ImagePullBackOff` → every dev-channel doc test times out waiting for the proxy to become ready.

We can't fix an upstream nightly from this repo, so instead of going red on something outside our control, the workflow now resolves the newest *fully published* dev build and uses that for the run.

## How it works

Two additions to `.github/workflows/doc-tests.yaml`:

1. **`discover` job — `Resolve installable dev build version`**: checks whether `0.0.0-latest-dev`'s chart references an image that actually exists in the registry.
   - If it does (healthy nightly) → keeps `0.0.0-latest-dev`.
   - If not (broken nightly) → walks recent **successful** `nightly.yml` runs newest-first and picks the most recent immutable `0.0.0-alpha.<sha>` build whose chart **and** image both exist.
   - On any error or if nothing is found → falls back to `0.0.0-latest-dev` (today's behavior), so it can never make things worse.
2. **`run-test` job — `Pin dev build version`**: if the resolved version differs from `0.0.0-latest-dev`, overwrites `patch-dev.md` in the CI checkout for that run only.

## Behavior summary

| Upstream nightly | Tests install |
|---|---|
| Healthy | `0.0.0-latest-dev` — `patch-dev.md` as committed, untouched |
| Broken (chart present, image missing) | Last good `0.0.0-alpha.<sha>` — usually the previous day's nightly |
| Can't resolve / none found | `0.0.0-latest-dev` — current behavior, no regression |

## Scope and notes

- Only `assets/agw-docs/versions/patch-dev.md` is ever read or rewritten. Released-channel pages are unaffected.
- The rewrite lives only in the ephemeral CI checkout — **the published docs still ship `0.0.0-latest-dev`**. This intentionally does not surface the upstream breakage to readers; using a nightly build carries that risk inherently.
- The fallback stays on the nightly channel (`0.0.0-alpha.<sha>`); it will never jump to a tagged release.
- Requires `helm` and `docker buildx` on the `discover` runner (both preinstalled on `ubuntu-latest`); if absent, the resolver just falls back to the default.
- Only catches the "chart published, image missing" failure mode via a registry-existence check. A different break (e.g. a chart that installs but crashes at runtime) would not be caught — that would need an actual smoke-install.

## Testing

Reproduced the current broken state and ran the full resolver under the exact CI shell (`bash -e -o pipefail`) against the live registry:

- `0.0.0-latest-dev` → `appVersion 0.0.0-alpha.50351263` → image missing → not installable → fallback triggered.
- Fallback resolved `0.0.0-alpha.068b1f3c` (last successful nightly, 2026-07-08), whose chart and `v0.0.0-alpha.068b1f3c` image both exist → clean exit 0.
