### PR TITLE
docs: Add cloud-provider-kind hint for Kind clusters using LoadBalancer

### DIFF
--- a/assets/agw-docs/snippets/agentgateway-setup.md
+++ b/assets/agw-docs/snippets/agentgateway-setup.md
@@ -40,6 +40,8 @@
 
    {{< tabs >}}
    {{% tab name="Cloud Provider LoadBalancer" %}}
+   {{< reuse "agw-docs/snippets/kind-loadbalancer-tip.md" >}}
+
    Verify that the external IP has been created and is not `pending`.
    ```sh
    kubectl get svc -n {{< reuse "agw-docs/snippets/namespace.md" >}} agentgateway-proxy

--- a/assets/agw-docs/snippets/agw-get-gateway-url-k8s.md
+++ b/assets/agw-docs/snippets/agw-get-gateway-url-k8s.md
@@ -1,5 +1,7 @@
 {{< tabs >}}
 {{% tab name="Cloud Provider LoadBalancer IP address" %}}
+{{< reuse "agw-docs/snippets/kind-loadbalancer-tip.md" >}}
+
 ```sh {paths="llm-clients-k8s-gateway-url"}
 export INGRESS_GW_ADDRESS=$(kubectl get svc -n {{< reuse "agw-docs/snippets/namespace.md" >}} agentgateway-proxy \
   -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -8,6 +10,8 @@ echo "Gateway address: $INGRESS_GW_ADDRESS"
 ```
 {{% /tab %}}
 {{% tab name="Cloud Provider LoadBalancer Hostname" %}}
+{{< reuse "agw-docs/snippets/kind-loadbalancer-tip.md" >}}
+
 ```sh
 export INGRESS_GW_ADDRESS=$(kubectl get svc -n {{< reuse "agw-docs/snippets/namespace.md" >}} agentgateway-proxy \
   -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')

--- a/assets/agw-docs/snippets/ai-gateway-address.md
+++ b/assets/agw-docs/snippets/ai-gateway-address.md
@@ -2,6 +2,8 @@ Get the external address of the gateway and save it in an environment variable.
    
    {{< tabs >}}
    {{< tab name="Cloud Provider LoadBalancer" >}}
+   {{< reuse "agw-docs/snippets/kind-loadbalancer-tip.md" >}}
+
    ```sh
    export INGRESS_GW_ADDRESS=$(kubectl get svc -n {{< reuse "agw-docs/snippets/namespace.md" >}} ai-gateway -o jsonpath="{.status.loadBalancer.ingress[0]['hostname','ip']}")
    echo $INGRESS_GW_ADDRESS  

--- a/assets/agw-docs/snippets/kind-loadbalancer-tip.md
+++ b/assets/agw-docs/snippets/kind-loadbalancer-tip.md
@@ -1,0 +1,3 @@
+{{< callout type="tip" >}}
+**Kind cluster?** Kind does not support `LoadBalancer` services by default. To use this option with a Kind cluster, install and run [`cloud-provider-kind`](https://github.com/kubernetes-sigs/cloud-provider-kind).
+{{< /callout >}}

--- a/assets/agw-docs/snippets/prereq.md
+++ b/assets/agw-docs/snippets/prereq.md
@@ -5,6 +5,8 @@
 3. Get the external address of the gateway and save it in an environment variable.
    {{< tabs >}}
    {{% tab name="Cloud Provider LoadBalancer" %}}
+   {{< reuse "agw-docs/snippets/kind-loadbalancer-tip.md" >}}
+
    ```sh
    export INGRESS_GW_ADDRESS=$(kubectl get svc -n {{< reuse "agw-docs/snippets/namespace.md" >}} http -o jsonpath="{.status.loadBalancer.ingress[0]['hostname','ip']}")
    echo $INGRESS_GW_ADDRESS  


### PR DESCRIPTION
Updates shared documentation snippets to include a tip for Kind users attempting to use Cloud Provider LoadBalancer configurations, pointing them to `cloud-provider-kind`. 
Fixes #705 .
