### PR TITLE
docs: add OpenAI-compatible client guides

### DIFF
--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s.md
@@ -1,7 +1,12 @@
+Agentgateway exposes an OpenAI-compatible API for supported clients. Configure
+each client with the Gateway address and a model name that agentgateway accepts,
+aliases, rewrites, or routes.
+
 Select a client below for configuration instructions.
 
 {{< cards >}}
   {{< card link="claude-code" title="Claude Code" subtitle="AI coding CLI by Anthropic" >}}
+  {{< card link="codex" title="Codex" subtitle="AI coding tool by OpenAI" >}}
   {{< card link="cursor" title="Cursor" subtitle="AI code editor with custom model support" >}}
   {{< card link="devin" title="Devin Desktop" subtitle="AI code editor from Cognition (formerly Windsurf)" >}}
   {{< card link="github-copilot" title="GitHub Copilot" subtitle="AI pair programmer" >}}

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -22,6 +22,11 @@ export AGENTGATEWAY_BASE_URL="http://${INGRESS_GW_ADDRESS}/v1"
 For a TLS-enabled gateway, set `AGENTGATEWAY_BASE_URL` to its HTTPS URL ending
 in `/v1`.
 
+## Verify gateway connectivity
+
+Follow [Step 4 of the OpenAI quickstart]({{< link-hextra path="/quickstart/llm/#step-4-send-a-request-to-the-llm" >}})
+to verify that the configured Gateway can reach the LLM provider.
+
 ## Connect Codex to agentgateway
 
 ### Codex CLI
@@ -69,6 +74,25 @@ codex --profile agentgateway
 {{% /tab %}}
 {{< /tabs >}}
 
+#### Verify the CLI connection
+
+1. Send a test prompt through agentgateway. For the profile configuration,
+   include the profile name:
+
+   ```sh
+   codex --profile agentgateway "Hello"
+   ```
+
+2. Verify that the request appears in the agentgateway proxy logs.
+
+   ```sh
+   kubectl logs deployment/agentgateway-proxy -n {{< reuse "agw-docs/snippets/namespace.md" >}} --since=5m \
+     | grep 'http.path=/v1/responses' \
+     | tail -n 5
+   ```
+
+   A successful entry has `http.status=200` and `http.path=/v1/responses`.
+
 {{< callout type="info" >}}
 This configuration was tested with `codex-cli 0.144.4`.
 {{< /callout >}}
@@ -97,28 +121,11 @@ Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
 
-{{< callout type="info" >}}
-This configuration was tested with ChatGPT desktop app version `26.707.72221`.
-{{< /callout >}}
+#### Verify the app connection
 
-For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
-and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).
+1. Send a task from Codex in the ChatGPT desktop app.
 
-## Verify the connection
-
-1. Follow [Step 4 of the OpenAI quickstart]({{< link-hextra path="/quickstart/llm/#step-4-send-a-request-to-the-llm" >}})
-   to verify that the configured Gateway can reach the LLM provider.
-
-2. Send a test prompt through agentgateway from the configured Codex CLI. For
-   the profile configuration, include the profile name:
-
-   ```sh
-   codex --profile agentgateway "Hello"
-   ```
-
-   Or send a task from Codex in the ChatGPT desktop app.
-
-3. Verify that the request appears in the agentgateway proxy logs.
+2. Verify that the request appears in the agentgateway proxy logs.
 
    ```sh
    kubectl logs deployment/agentgateway-proxy -n {{< reuse "agw-docs/snippets/namespace.md" >}} --since=5m \
@@ -127,6 +134,13 @@ and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/
    ```
 
    A successful entry has `http.status=200` and `http.path=/v1/responses`.
+
+{{< callout type="info" >}}
+This configuration was tested with ChatGPT desktop app version `26.707.72221`.
+{{< /callout >}}
+
+For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
+and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).
 
 Codex also probes `/v1/models` to discover model metadata. Until
 [agentgateway issue #1462](https://github.com/agentgateway/agentgateway/issues/1462)

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -29,17 +29,6 @@ in `/v1`.
 Point Codex at agentgateway through one of the following methods.
 
 {{< tabs >}}
-{{% tab name="Environment variable" %}}
-
-Codex uses the [OPENAI_BASE_URL](https://developers.openai.com/codex/config-advanced)
-environment variable to override the default OpenAI endpoint.
-
-```sh
-export OPENAI_BASE_URL="$AGENTGATEWAY_BASE_URL"
-codex
-```
-
-{{% /tab %}}
 {{% tab name="CLI override" %}}
 
 To override the base URL for a single run, set `model_provider` and the

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -1,37 +1,25 @@
-Configure [Codex](https://chatgpt.com/codex), the AI coding tool by OpenAI, to route requests through your agentgateway proxy.
+Configure [Codex](https://chatgpt.com/codex), the AI coding tool by OpenAI, to
+route requests through agentgateway running in Kubernetes.
 
 ## Before you begin
 
-1. {{< reuse "agw-docs/snippets/prereq-agentgateway.md" >}}
-2. [Install the Codex CLI](https://developers.openai.com/codex/cli/).
+1. Set up an [agentgateway proxy]({{< link-hextra path="/setup/gateway/" >}}).
+2. [Set up access to the OpenAI LLM provider]({{< link-hextra path="/llm/providers/openai/" >}}).
+3. [Install the Codex CLI](https://developers.openai.com/codex/cli/).
 
-## Configure agentgateway
+## Set the gateway URL
 
-Start agentgateway with an OpenAI backend configuration. The wildcard `*` model name accepts any model. Codex sends the model in each request, so you do not need to pin a specific model.
+The [OpenAI quickstart]({{< link-hextra path="/quickstart/llm/#step-4-send-a-request-to-the-llm" >}})
+uses `INGRESS_GW_ADDRESS` for the Gateway address. Set the Codex base URL from
+that value. The `/v1` suffix is required because Codex sends Responses API
+requests to `/v1/responses`.
 
-1. Create a configuration file.
+```sh
+export AGENTGATEWAY_BASE_URL="http://${INGRESS_GW_ADDRESS}/v1"
+```
 
-   ```yaml
-   cat > config.yaml << 'EOF'
-   # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   llm:
-     models:
-     - name: "*"
-       provider: openAI
-       params:
-         apiKey: "$OPENAI_API_KEY"
-   EOF
-   ```
-
-2. Start agentgateway.
-
-   ```bash
-   agentgateway -f config.yaml
-   ```
-
-{{< callout type="info" >}}
-For wildcard model matching, rate limiting, and other options, see the [OpenAI provider page]({{< link-hextra path="/llm/providers/openai" >}}).
-{{< /callout >}}
+For a TLS-enabled gateway, set `AGENTGATEWAY_BASE_URL` to its HTTPS URL ending
+in `/v1`.
 
 ## Connect Codex to agentgateway
 
@@ -44,20 +32,25 @@ Point Codex at agentgateway through one of the following methods.
 {{< tabs >}}
 {{% tab name="Environment variable" %}}
 
-Codex uses the [OPENAI_BASE_URL](https://developers.openai.com/codex/config-advanced) environment variable to override the default OpenAI endpoint. Use a base URL that includes `/v1` so requests go to `/v1/responses` and OpenAI does not return 404.
+Codex uses the [OPENAI_BASE_URL](https://developers.openai.com/codex/config-advanced)
+environment variable to override the default OpenAI endpoint.
 
 ```sh
-export OPENAI_BASE_URL="http://localhost:4000/v1"
+export OPENAI_BASE_URL="$AGENTGATEWAY_BASE_URL"
 codex
 ```
 
 {{% /tab %}}
 {{% tab name="CLI override" %}}
 
-To override the base URL for a single run, set `model_provider` and the provider's `name` and `base_url` (the `-c` values are TOML).
+To override the base URL for a single run, set `model_provider` and the
+provider's `name` and `base_url` (the `-c` values are TOML).
 
 ```sh
-codex -c 'model_provider="proxy"' -c 'model_providers.proxy.name="OpenAI via agentgateway"' -c 'model_providers.proxy.base_url="http://localhost:4000/v1"'
+codex -c 'model_provider="agentgateway"' \
+  -c 'model_providers.agentgateway.name="OpenAI via agentgateway"' \
+  -c "model_providers.agentgateway.base_url=\"${AGENTGATEWAY_BASE_URL}\"" \
+  -c 'model_providers.agentgateway.wire_api="responses"'
 ```
 
 {{% /tab %}}
@@ -66,19 +59,20 @@ codex -c 'model_provider="proxy"' -c 'model_providers.proxy.name="OpenAI via age
 To configure the base URL persistently without changing your default Codex
 configuration, create a profile. For more information, see [Codex
 profiles](https://learn.chatgpt.com/docs/config-file/config-advanced#profiles).
-The `name` field is required for custom providers.
 
-```toml
+```sh
+mkdir -p ~/.codex
+cat > ~/.codex/agentgateway.config.toml <<EOF
 model_provider = "agentgateway"
 
 [model_providers.agentgateway]
 name = "OpenAI via agentgateway"
-base_url = "http://localhost:4000/v1"
+base_url = "${AGENTGATEWAY_BASE_URL}"
 wire_api = "responses"
+EOF
 ```
 
-Save the configuration as `~/.codex/agentgateway.config.toml`, then start
-Codex with the profile:
+Start Codex with the profile:
 
 ```sh
 codex --profile agentgateway
@@ -99,12 +93,12 @@ user-level configuration, then restart the ChatGPT desktop app:
 
 ```sh
 cp ~/.codex/config.toml ~/.codex/config.toml.bak
-cat > ~/.codex/config.toml <<'EOF'
+cat > ~/.codex/config.toml <<EOF
 model_provider = "agentgateway"
 
 [model_providers.agentgateway]
 name = "OpenAI via agentgateway"
-base_url = "http://localhost:4000/v1"
+base_url = "${AGENTGATEWAY_BASE_URL}"
 wire_api = "responses"
 EOF
 ```
@@ -115,20 +109,27 @@ Open config.toml** and apply the same provider configuration.
 
 ## Verify the connection
 
-1. Send a test prompt through agentgateway. For the profile configuration,
-   include the profile name:
+1. Follow [Step 4 of the OpenAI quickstart]({{< link-hextra path="/quickstart/llm/#step-4-send-a-request-to-the-llm" >}})
+   to verify that the configured Gateway can reach the LLM provider.
 
-   ```bash
+2. Send a test prompt through agentgateway from the configured Codex CLI. For
+   the profile configuration, include the profile name:
+
+   ```sh
    codex --profile agentgateway "Hello"
    ```
 
-2. Verify that the request appears in the agentgateway logs.
+   Or send a task from Codex in the ChatGPT desktop app.
 
-   Example output:
+3. Verify that the request appears in the agentgateway proxy logs.
 
+   ```sh
+   kubectl logs deployment/agentgateway-proxy -n {{< reuse "agw-docs/snippets/namespace.md" >}} --since=5m \
+     | grep 'http.path=/v1/responses' \
+     | tail -n 5
    ```
-   info  request gateway=default/default listener=llm route=internal/model:* endpoint=api.openai.com:443 http.method=POST http.path=/v1/responses http.status=200 protocol=llm gen_ai.operation.name=chat gen_ai.provider.name=openai duration=1687ms
-   ```
+
+   A successful entry has `http.status=200` and `http.path=/v1/responses`.
 
 Codex also probes `/v1/models` to discover model metadata. Until
 [agentgateway issue #1462](https://github.com/agentgateway/agentgateway/issues/1462)

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -19,8 +19,10 @@ requests to `/v1/responses`.
 export AGENTGATEWAY_BASE_URL="http://${INGRESS_GW_ADDRESS}/v1"
 ```
 
+{{< callout type="info" >}}
 For a TLS-enabled gateway, set `AGENTGATEWAY_BASE_URL` to its HTTPS URL ending
 in `/v1`.
+{{< /callout >}}
 
 ## Verify gateway connectivity
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -117,7 +117,6 @@ wire_api = "responses"
 EOF
 ```
 
-Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -5,7 +5,8 @@ route requests through agentgateway running in Kubernetes.
 
 1. Set up an [agentgateway proxy]({{< link-hextra path="/setup/gateway/" >}}).
 2. [Set up access to the OpenAI LLM provider]({{< link-hextra path="/llm/providers/openai/" >}}).
-3. [Install the Codex CLI](https://developers.openai.com/codex/cli/).
+3. Install either the [Codex CLI](https://developers.openai.com/codex/cli/) or
+   the [ChatGPT desktop app](https://chatgpt.com/download/).
 
 ## Set the gateway URL
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -26,8 +26,6 @@ in `/v1`.
 
 ### Codex CLI
 
-For more configuration options, see the [Codex CLI documentation](https://developers.openai.com/codex/cli/).
-
 Point Codex at agentgateway through one of the following methods.
 
 {{< tabs >}}
@@ -82,12 +80,12 @@ codex --profile agentgateway
 {{% /tab %}}
 {{< /tabs >}}
 
+For more configuration options, see the [**Codex CLI documentation**](https://developers.openai.com/codex/cli/).
+
 ### Codex in the ChatGPT Desktop App
 
 Codex is available in the ChatGPT desktop app. This configuration was tested
-with ChatGPT desktop app version `26.707.72221`. For more information, see the
-[Codex app documentation](https://learn.chatgpt.com/docs/environments/modes)
-and [Codex configuration basics](https://learn.chatgpt.com/docs/config-file/config-basic).
+with ChatGPT desktop app version `26.707.72221`.
 
 To use the same provider configuration with the app, back up and replace the
 user-level configuration, then restart the ChatGPT desktop app:
@@ -107,6 +105,9 @@ EOF
 Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
+
+For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
+and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).
 
 ## Verify the connection
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -77,10 +77,9 @@ For more configuration options, see the [**Codex CLI documentation**](https://de
 
 ### Codex in the ChatGPT Desktop App
 
-Codex is available in the ChatGPT desktop app.
-
-To use the same provider configuration with the app, back up and replace the
-user-level configuration, then restart the ChatGPT desktop app:
+Codex is available in the ChatGPT desktop app. To use the same provider
+configuration with the app, back up and replace the user-level configuration,
+then restart the ChatGPT desktop app:
 
 ```sh
 cp ~/.codex/config.toml ~/.codex/config.toml.bak

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -69,12 +69,15 @@ codex --profile agentgateway
 {{% /tab %}}
 {{< /tabs >}}
 
+{{< callout type="info" >}}
+This configuration was tested with `codex-cli 0.144.4`.
+{{< /callout >}}
+
 For more configuration options, see the [**Codex CLI documentation**](https://developers.openai.com/codex/cli/).
 
 ### Codex in the ChatGPT Desktop App
 
-Codex is available in the ChatGPT desktop app. This configuration was tested
-with ChatGPT desktop app version `26.707.72221`.
+Codex is available in the ChatGPT desktop app.
 
 To use the same provider configuration with the app, back up and replace the
 user-level configuration, then restart the ChatGPT desktop app:
@@ -94,6 +97,10 @@ EOF
 Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
+
+{{< callout type="info" >}}
+This configuration was tested with ChatGPT desktop app version `26.707.72221`.
+{{< /callout >}}
 
 For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
 and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md
@@ -10,8 +10,8 @@ route requests through agentgateway running in Kubernetes.
 
 ## Set the gateway URL
 
-The [OpenAI quickstart]({{< link-hextra path="/quickstart/llm/#step-4-send-a-request-to-the-llm" >}})
-uses `INGRESS_GW_ADDRESS` for the Gateway address. Set the Codex base URL from
+The [installation quickstart]({{< link-hextra path="/quickstart/install/" >}})
+sets `INGRESS_GW_ADDRESS` to the Gateway address. Set the Codex base URL from
 that value. The `/v1` suffix is required because Codex sends Responses API
 requests to `/v1/responses`.
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -38,8 +38,6 @@ For wildcard model matching, rate limiting, and other options, see the [OpenAI p
 
 ### Codex CLI
 
-For more configuration options, see the [Codex CLI documentation](https://developers.openai.com/codex/cli/).
-
 Point Codex at agentgateway through one of the following methods.
 
 {{< tabs >}}
@@ -88,12 +86,12 @@ codex --profile agentgateway
 {{% /tab %}}
 {{< /tabs >}}
 
+For more configuration options, see the [**Codex CLI documentation**](https://developers.openai.com/codex/cli/).
+
 ### Codex in the ChatGPT Desktop App
 
 Codex is available in the ChatGPT desktop app. This configuration was tested
-with ChatGPT desktop app version `26.707.72221`. For more information, see the
-[Codex app documentation](https://learn.chatgpt.com/docs/environments/modes)
-and [Codex configuration basics](https://learn.chatgpt.com/docs/config-file/config-basic).
+with ChatGPT desktop app version `26.707.72221`.
 
 To use the same provider configuration with the app, back up and replace the
 user-level configuration, then restart the ChatGPT desktop app:
@@ -113,6 +111,9 @@ EOF
 Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
+
+For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
+and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).
 
 ## Verify the connection
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -78,6 +78,23 @@ codex --profile agentgateway
 {{% /tab %}}
 {{< /tabs >}}
 
+#### Verify the CLI connection
+
+1. Send a test prompt through agentgateway. For the profile configuration,
+   include the profile name:
+
+   ```bash
+   codex --profile agentgateway "Hello"
+   ```
+
+2. Verify that the request appears in the agentgateway logs.
+
+   Example output:
+
+   ```
+   info  request gateway=default/default listener=llm route=internal/model:* endpoint=api.openai.com:443 http.method=POST http.path=/v1/responses http.status=200 protocol=llm gen_ai.operation.name=chat gen_ai.provider.name=openai duration=1687ms
+   ```
+
 {{< callout type="info" >}}
 This configuration was tested with `codex-cli 0.144.4`.
 {{< /callout >}}
@@ -106,21 +123,9 @@ Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
 
-{{< callout type="info" >}}
-This configuration was tested with ChatGPT desktop app version `26.707.72221`.
-{{< /callout >}}
+#### Verify the app connection
 
-For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
-and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).
-
-## Verify the connection
-
-1. Send a test prompt through agentgateway. For the profile configuration,
-   include the profile name:
-
-   ```bash
-   codex --profile agentgateway "Hello"
-   ```
+1. Send a task from Codex in the ChatGPT desktop app.
 
 2. Verify that the request appears in the agentgateway logs.
 
@@ -129,6 +134,13 @@ and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/
    ```
    info  request gateway=default/default listener=llm route=internal/model:* endpoint=api.openai.com:443 http.method=POST http.path=/v1/responses http.status=200 protocol=llm gen_ai.operation.name=chat gen_ai.provider.name=openai duration=1687ms
    ```
+
+{{< callout type="info" >}}
+This configuration was tested with ChatGPT desktop app version `26.707.72221`.
+{{< /callout >}}
+
+For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
+and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).
 
 Codex also probes `/v1/models` to discover model metadata. Until
 [agentgateway issue #1462](https://github.com/agentgateway/agentgateway/issues/1462)

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -57,17 +57,19 @@ configuration, create a profile. For more information, see [Codex
 profiles](https://learn.chatgpt.com/docs/config-file/config-advanced#profiles).
 The `name` field is required for custom providers.
 
-```toml
+```sh
+mkdir -p ~/.codex
+cat > ~/.codex/agentgateway.config.toml <<'EOF'
 model_provider = "agentgateway"
 
 [model_providers.agentgateway]
 name = "OpenAI via agentgateway"
 base_url = "http://localhost:4000/v1"
 wire_api = "responses"
+EOF
 ```
 
-Save the configuration as `~/.codex/agentgateway.config.toml`, then start
-Codex with the profile:
+Start Codex with the profile:
 
 ```sh
 codex --profile agentgateway

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -41,16 +41,6 @@ For wildcard model matching, rate limiting, and other options, see the [OpenAI p
 Point Codex at agentgateway through one of the following methods.
 
 {{< tabs >}}
-{{% tab name="Environment variable" %}}
-
-Codex uses the [OPENAI_BASE_URL](https://developers.openai.com/codex/config-advanced) environment variable to override the default OpenAI endpoint. Use a base URL that includes `/v1` so requests go to `/v1/responses` and OpenAI does not return 404.
-
-```sh
-export OPENAI_BASE_URL="http://localhost:4000/v1"
-codex
-```
-
-{{% /tab %}}
 {{% tab name="CLI override" %}}
 
 To override the base URL for a single run, set `model_provider` and the provider's `name` and `base_url` (the `-c` values are TOML).

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -86,10 +86,9 @@ For more configuration options, see the [**Codex CLI documentation**](https://de
 
 ### Codex in the ChatGPT Desktop App
 
-Codex is available in the ChatGPT desktop app.
-
-To use the same provider configuration with the app, back up and replace the
-user-level configuration, then restart the ChatGPT desktop app:
+Codex is available in the ChatGPT desktop app. To use the same provider
+configuration with the app, back up and replace the user-level configuration,
+then restart the ChatGPT desktop app:
 
 ```sh
 cp ~/.codex/config.toml ~/.codex/config.toml.bak

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -3,7 +3,8 @@ Configure [Codex](https://chatgpt.com/codex), the AI coding tool by OpenAI, to r
 ## Before you begin
 
 1. {{< reuse "agw-docs/snippets/prereq-agentgateway.md" >}}
-2. [Install the Codex CLI](https://developers.openai.com/codex/cli/).
+2. Install either the [Codex CLI](https://developers.openai.com/codex/cli/) or
+   the [ChatGPT desktop app](https://chatgpt.com/download/).
 
 ## Configure agentgateway
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -78,12 +78,15 @@ codex --profile agentgateway
 {{% /tab %}}
 {{< /tabs >}}
 
+{{< callout type="info" >}}
+This configuration was tested with `codex-cli 0.144.4`.
+{{< /callout >}}
+
 For more configuration options, see the [**Codex CLI documentation**](https://developers.openai.com/codex/cli/).
 
 ### Codex in the ChatGPT Desktop App
 
-Codex is available in the ChatGPT desktop app. This configuration was tested
-with ChatGPT desktop app version `26.707.72221`.
+Codex is available in the ChatGPT desktop app.
 
 To use the same provider configuration with the app, back up and replace the
 user-level configuration, then restart the ChatGPT desktop app:
@@ -103,6 +106,10 @@ EOF
 Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
+
+{{< callout type="info" >}}
+This configuration was tested with ChatGPT desktop app version `26.707.72221`.
+{{< /callout >}}
 
 For more information, see the [**Codex app documentation**](https://learn.chatgpt.com/docs/environments/modes)
 and [**Codex configuration basics**](https://learn.chatgpt.com/docs/config-file/config-basic).

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/codex.md
@@ -119,7 +119,6 @@ wire_api = "responses"
 EOF
 ```
 
-Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
 To edit the file through the app instead, open **Settings > Configuration >
 Open config.toml** and apply the same provider configuration.
 

--- a/content/docs/kubernetes/latest/integrations/llm-clients/codex.md
+++ b/content/docs/kubernetes/latest/integrations/llm-clients/codex.md
@@ -1,0 +1,7 @@
+---
+title: Codex
+weight: 10
+description: Configure Codex to use agentgateway running in Kubernetes
+---
+
+{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md" >}}

--- a/content/docs/kubernetes/main/integrations/llm-clients/codex.md
+++ b/content/docs/kubernetes/main/integrations/llm-clients/codex.md
@@ -1,0 +1,7 @@
+---
+title: Codex
+weight: 10
+description: Configure Codex to use agentgateway running in Kubernetes
+---
+
+{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients-k8s/codex.md" >}}


### PR DESCRIPTION
## Summary
- add Kubernetes guidance for an AI coding client through agentgateway
- refresh standalone client guidance with CLI profiles and desktop-app setup
- document verification and the known model-metadata limitation

## Validation
- hugo --gc --minify