### PR TITLE
Add preview workflows

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,88 @@
+# Preview build — untrusted half of the fork-preview pipeline.
+#
+# WHY TWO WORKFLOWS:
+# Cloudflare Pages' native Git integration does not build preview deployments
+# for PRs opened from forks: a fork cannot be trusted with the Cloudflare
+# credentials, so Cloudflare skips it. GitHub Actions has the same constraint —
+# a `pull_request` run triggered by a fork gets a read-only GITHUB_TOKEN and NO
+# access to repository secrets. That is exactly what we want here.
+#
+# This workflow runs in the FORK's context on every PR. It builds the site from
+# the PR's (untrusted) code with no secrets present, so there is nothing for a
+# malicious PR to steal. It uploads the built `public/` output plus the PR
+# number as artifacts. The companion `preview-deploy.yml` workflow then picks
+# those artifacts up in a TRUSTED context (where the Cloudflare token lives) and
+# does the actual deploy. It never executes any code from the fork — it only
+# ships the already-built static HTML.
+#
+# Do NOT add secrets, `pull_request_target`, or deploy steps to this file.
+# Anything that needs credentials belongs in preview-deploy.yml.
+
+name: Preview build
+
+on:
+  pull_request:
+    # Mirror the paths that actually affect the rendered site, matching
+    # framework-tests.yml. Drop this filter if you'd rather build on every PR.
+    paths:
+      - 'assets/**'
+      - 'content/**'
+      - 'layouts/**'
+      - 'static/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'hugo.yaml'
+      - '.github/workflows/preview-build.yml'
+
+# Cancel superseded builds when a PR is pushed to repeatedly.
+concurrency:
+  group: preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Hugo pulls the theme as a Hugo Module (see go.mod), so Go is required.
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3
+        with:
+          hugo-version: '0.160.1'
+          extended: true
+
+      # Production-style build, same flags as `make build`.
+      # --minify + --gc; no drafts/future content.
+      - name: Build
+        run: hugo --gc --minify
+
+      - name: Upload site
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: preview-site
+          path: public/
+          retention-days: 3
+          if-no-files-found: error
+
+      # Persist the PR number so the deploy workflow knows where to comment.
+      # workflow_run does not reliably carry the PR number for fork PRs, so we
+      # pass it explicitly through an artifact.
+      - name: Save PR metadata
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: preview-pr-meta
+          path: pr-number.txt
+          retention-days: 3
+          if-no-files-found: error

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,100 @@
+# Preview cleanup — removes Cloudflare Pages previews that are no longer needed.
+#
+# Cloudflare Pages has no time-to-live on preview deployments — a preview lives
+# until something deletes it. (`--temporary` is a Workers feature, not Pages, and
+# the build's artifact retention only expires the GitHub artifacts, not the live
+# preview.) This one workflow handles both ways a preview becomes stale:
+#
+#   1. pull_request_target [closed]  — the normal case. When a PR is merged or
+#      closed, delete every deployment made under its `pr-<number>` branch.
+#   2. schedule (daily)              — a backstop. Reconcile against open PRs and
+#      delete any `pr-*` previews whose PR is no longer open, in case an on-close
+#      run failed or a PR predates this pipeline.
+#
+# It deliberately does NOT delete by age: an age-based sweep would wipe the
+# preview of a still-open, long-lived PR. Reconciling against the open-PR list
+# only ever removes previews for PRs that are actually gone.
+#
+# WHY pull_request_target: a plain `pull_request` run from a fork gets no secrets
+# (the same limitation behind the build/deploy split). pull_request_target runs
+# in the base repo's context with secrets. Safe here because it checks out no code
+# and runs no fork scripts — it only reads the PR number and calls APIs.
+#
+# If you'd rather not run a scheduled job, delete the `schedule:` trigger below;
+# the on-close teardown alone covers the common case.
+
+name: Preview cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+  schedule:
+    - cron: '0 3 * * *' # daily 03:00 UTC
+  workflow_dispatch: {}   # manual reconciliation sweep
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: preview-cleanup-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete stale previews
+    runs-on: ubuntu-latest
+    env:
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CF_PROJECT: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+      EVENT_NAME: ${{ github.event_name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Delete preview deployments
+        run: |
+          set -euo pipefail
+          api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${CF_PROJECT}/deployments"
+
+          # Snapshot every deployment as {id, branch}, paginating the API.
+          all="$(mktemp)"
+          page=1
+          while : ; do
+            resp=$(curl -sf -H "Authorization: Bearer ${CF_API_TOKEN}" "${api}?page=${page}&per_page=25")
+            count=$(echo "$resp" | jq '.result | length')
+            [ "$count" -eq 0 ] && break
+            echo "$resp" | jq -c '.result[] | {id, branch: .deployment_trigger.metadata.branch}' >> "$all"
+            page=$((page + 1))
+          done
+
+          # Decide which pr-<n> branches to delete.
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # On close: just this PR's branch.
+            targets="pr-${PR_NUMBER}"
+          else
+            # Sweep: every pr-* branch whose PR is no longer open.
+            open="$(gh api --paginate "repos/${GH_REPO}/pulls?state=open" --jq '.[].number' | sed 's/^/pr-/' || true)"
+            branches=$(jq -r 'select(.branch != null and (.branch | test("^pr-[0-9]+$"))) | .branch' "$all" | sort -u)
+            targets=""
+            for b in $branches; do
+              if ! grep -qxF "$b" <<< "$open"; then
+                targets="$targets $b"
+              fi
+            done
+          fi
+
+          deleted=0
+          for b in $targets; do
+            ids=$(jq -r --arg b "$b" 'select(.branch == $b) | .id' "$all")
+            for id in $ids; do
+              echo "Deleting deployment ${id} (branch ${b})"
+              # ?force=true also removes deployments that still hold an alias.
+              curl -sf -X DELETE \
+                -H "Authorization: Bearer ${CF_API_TOKEN}" \
+                "${api}/${id}?force=true" > /dev/null
+              deleted=$((deleted + 1))
+            done
+          done
+          echo "Deleted ${deleted} deployment(s)"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,110 @@
+# Preview deploy — trusted half of the fork-preview pipeline.
+#
+# Triggered by `workflow_run` when "Preview build" finishes. A workflow_run
+# event ALWAYS runs from the base repository's default branch and in the base
+# repo's context, so repository secrets (the Cloudflare token) are available
+# even when the originating PR came from a fork. That is the whole point of the
+# split: the untrusted code was already built with no secrets in preview-build.yml,
+# and this workflow only ever handles the resulting static `public/` artifact —
+# it never checks out or executes fork code.
+#
+# SECURITY NOTES:
+#   - This file lives on the base branch; edits to it in a fork PR have no
+#     effect on the run (workflow_run always uses the base-branch definition).
+#   - We only download and deploy the built artifact. We do NOT run the fork's
+#     build scripts, Makefile, or any of its code here.
+#   - `pull-requests: write` is scoped to posting the preview-URL comment.
+
+name: Preview deploy
+
+on:
+  workflow_run:
+    workflows: ["Preview build"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+  # Needed by actions/download-artifact to pull artifacts from another run.
+  actions: read
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    # Only deploy successful builds that came from a PR (i.e. a fork or branch
+    # PR), never from pushes or failed builds.
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download built site
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: preview-site
+          path: public
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download PR metadata
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: preview-pr-meta
+          path: pr-meta
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-meta/pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      # Deploy the static output. A non-production --branch value makes this a
+      # Cloudflare Pages *preview* deployment with its own unique URL, kept
+      # separate from the production (main) deployment.
+      - name: Deploy to Cloudflare Pages
+        id: cf
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Set this to your Cloudflare Pages project name (repo/org variable).
+          command: >
+            pages deploy public
+            --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}
+            --branch=pr-${{ steps.pr.outputs.number }}
+            --commit-hash=${{ github.event.workflow_run.head_sha }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const url = '${{ steps.cf.outputs.deployment-url }}';
+            const marker = '<!-- cf-preview -->';
+            const body = `${marker}\n### 🚀 Cloudflare preview\n\n`
+              + `Preview for this PR: ${url}\n\n`
+              + `_Built from ${context.payload.workflow_run.head_sha.slice(0, 7)} · updates on each push._`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
- updates PRs to use workflows to build previews, instead of relying on Cloudflare
- cleanup workflow runs on PR close as well as daily to clean up any stale preview branches
- multi-workflow approach so that forks can get preview links, too