### PR TITLE
Docs for binds to gateways draft

### DIFF
--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code-13x.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-code-13x.md
@@ -129,30 +129,31 @@ If you have a Claude Teams or Pro account, you can use agentgateway for request 
 
    ```yaml
    cat > config.yaml << 'EOF'
-   gateways:
-     default:
-       port: 4001
+   binds:
+   - port: 4001
+     listeners:
+     - name: default
        protocol: HTTP
-   routes:
-   - name: claude-agent
-     matches:
-     - path:
-         pathPrefix: /claude
-     policies:
-       urlRewrite:
-         path:
-           prefix: /
-     backends:
-     - ai:
-         name: claude-agent
-         provider:
-           anthropic: {}
+       routes:
+       - name: claude-agent
+         matches:
+         - path:
+             pathPrefix: /claude
          policies:
-           ai:
-             routes:
-               /v1/messages: messages
-               /v1/messages/count_tokens: anthropicTokenCount
-               '*': passthrough
+           urlRewrite:
+             path:
+               prefix: /
+         backends:
+         - ai:
+             name: claude-agent
+             provider:
+               anthropic: {}
+             policies:
+               ai:
+                 routes:
+                   /v1/messages: messages
+                   /v1/messages/count_tokens: anthropicTokenCount
+                   '*': passthrough
    EOF
    ```
 

--- a/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-desktop-13x.md
+++ b/assets/agw-docs/pages/agentgateway/integrations/llm-clients/claude-desktop-13x.md
@@ -15,30 +15,31 @@ Start agentgateway with the Teams configuration. Agentgateway listens on port `4
 
    ```yaml
    cat > config.yaml << 'EOF'
-   gateways:
-     default:
-       port: 4001
+   binds:
+   - port: 4001
+     listeners:
+     - name: default
        protocol: HTTP
-   routes:
-   - name: claude-agent
-     matches:
-     - path:
-         pathPrefix: /claude
-     policies:
-       urlRewrite:
-         path:
-           prefix: /
-     backends:
-     - ai:
-         name: claude-agent
-         provider:
-           anthropic: {}
+       routes:
+       - name: claude-agent
+         matches:
+         - path:
+             pathPrefix: /claude
          policies:
-           ai:
-             routes:
-               /v1/messages: messages
-               /v1/messages/count_tokens: anthropicTokenCount
-               '*': passthrough
+           urlRewrite:
+             path:
+               prefix: /
+         backends:
+         - ai:
+             name: claude-agent
+             provider:
+               anthropic: {}
+             policies:
+               ai:
+                 routes:
+                   /v1/messages: messages
+                   /v1/messages/count_tokens: anthropicTokenCount
+                   '*': passthrough
    EOF
    ```
 

--- a/assets/agw-docs/pages/conditional-policies-13x.md
+++ b/assets/agw-docs/pages/conditional-policies-13x.md
@@ -32,26 +32,26 @@ Route to one of two external authorization servers based on the request path. Re
 {{< conditional-text include-if="standalone" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-gateways:
-  default:
-    port: 3000
-routes:
-- backends:
-  - host: localhost:8000
-  policies:
-    extAuthz:
-      conditional:
-      # Admin paths go to the stricter authorization server.
-      - condition: request.path.startsWith("/admin")
-        host: localhost:9000
-        protocol:
-          grpc: {}
-        failureMode: deny
-      # Fallback for every other request. No condition, must be last.
-      - host: localhost:9001
-        protocol:
-          grpc: {}
-        failureMode: deny
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: localhost:8000
+      policies:
+        extAuthz:
+          conditional:
+          # Admin paths go to the stricter authorization server.
+          - condition: request.path.startsWith("/admin")
+            host: localhost:9000
+            protocol:
+              grpc: {}
+            failureMode: deny
+          # Fallback for every other request. No condition, must be last.
+          - host: localhost:9001
+            protocol:
+              grpc: {}
+            failureMode: deny
 ```
 {{< /conditional-text >}}
 
@@ -94,24 +94,24 @@ Apply a stricter rate limit to write requests and a looser limit to all other tr
 
 {{< conditional-text include-if="standalone" >}}
 ```yaml
-gateways:
-  default:
-    port: 3000
-routes:
-- backends:
-  - host: localhost:8000
-  policies:
-    localRateLimit:
-      conditional:
-      - condition: request.method == "POST" || request.method == "PUT" || request.method == "DELETE"
-        maxTokens: 10
-        tokensPerFill: 10
-        fillInterval: 1m
-        type: requests
-      - maxTokens: 100
-        tokensPerFill: 100
-        fillInterval: 1m
-        type: requests
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: localhost:8000
+      policies:
+        localRateLimit:
+          conditional:
+          - condition: request.method == "POST" || request.method == "PUT" || request.method == "DELETE"
+            maxTokens: 10
+            tokensPerFill: 10
+            fillInterval: 1m
+            type: requests
+          - maxTokens: 100
+            tokensPerFill: 100
+            fillInterval: 1m
+            type: requests
 ```
 {{< /conditional-text >}}
 
@@ -148,19 +148,19 @@ Add a tracing header when the request includes an `x-internal: true` header. Wit
 
 {{< conditional-text include-if="standalone" >}}
 ```yaml
-gateways:
-  default:
-    port: 3000
-routes:
-- backends:
-  - host: localhost:8000
-  policies:
-    transformations:
-      conditional:
-      - condition: request.headers["x-internal"] == "true"
-        request:
-          add:
-            x-trace-source: '"internal"'
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: localhost:8000
+      policies:
+        transformations:
+          conditional:
+          - condition: request.headers["x-internal"] == "true"
+            request:
+              add:
+                x-trace-source: '"internal"'
 ```
 {{< /conditional-text >}}
 
@@ -194,18 +194,18 @@ Send requests on a path that starts with `/v1/chat` through an external processo
 
 {{< conditional-text include-if="standalone" >}}
 ```yaml
-gateways:
-  default:
-    port: 3000
-routes:
-- backends:
-  - host: localhost:8000
-  policies:
-    extProc:
-      conditional:
-      - condition: request.path.startsWith("/v1/chat")
-        host: localhost:9100
-        failureMode: failClosed
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: localhost:8000
+      policies:
+        extProc:
+          conditional:
+          - condition: request.path.startsWith("/v1/chat")
+            host: localhost:9100
+            failureMode: failClosed
 ```
 {{< /conditional-text >}}
 
@@ -238,18 +238,18 @@ Return a `410 Gone` response for any path that starts with `/v0/`. Every other r
 
 {{< conditional-text include-if="standalone" >}}
 ```yaml
-gateways:
-  default:
-    port: 3000
-routes:
-- backends:
-  - host: localhost:8000
-  policies:
-    directResponse:
-      conditional:
-      - condition: request.path.startsWith("/v0/")
-        status: 410
-        body: "This API version is no longer available. Use /v1/."
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: localhost:8000
+      policies:
+        directResponse:
+          conditional:
+          - condition: request.path.startsWith("/v0/")
+            status: 410
+            body: "This API version is no longer available. Use /v1/."
 ```
 {{< /conditional-text >}}
 

--- a/assets/agw-docs/pages/observability/traces-13x.md
+++ b/assets/agw-docs/pages/observability/traces-13x.md
@@ -41,17 +41,17 @@ Static tracing is configured globally and applies to all routes.
 3. Optional: To use the agentgateway UI playground later, add the following CORS policy to your `config.yaml` file. The config automatically reloads when you save the file.
       
       ```yaml
-      gateways:
-        default:
-          port: 3000
-      routes:
-      - policies:
-          cors:
-            allowOrigins:
-              - "*"
-            allowHeaders:
-              - "*"
-        backends:
+      binds:
+      - port: 3000
+        listeners:
+        - routes:
+          - policies:
+              cors:
+                allowOrigins:
+                  - "*"
+                allowHeaders:
+                  - "*"
+            backends:
       ...
       ```
 
@@ -96,29 +96,30 @@ frontendPolicies:
       route: request.path
     resources:
       service.name: '"agentgateway"'
-gateways:
-  default:
-    port: 3000
-routes:
-- policies:
-    cors:
-      allowOrigins:
-        - "*"
-      allowHeaders:
-        - "*"
-  backends:
-  - mcp:
-      targets:
-      - name: everything
-        stdio:
-          cmd: npx
-          args: ["@modelcontextprotocol/server-everything"]
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - policies:
+        cors:
+          allowOrigins:
+            - "*"
+          allowHeaders:
+            - "*"
+      backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]
 ```
 
 ## Verify traces
 
 1. Open the [agentgateway UI](http://localhost:15000/ui/) to view your listener and target configuration.
 
+{{< version exclude-if="1.2.x,1.1.x,1.0.x" >}}
 2. Connect to the MCP server with the agentgateway UI playground.
 
    1. From the navigation menu under **MCP**, click **Tool Playground**.
@@ -139,6 +140,27 @@ routes:
 
       {{< reuse-image-light src="img/agentgateway-ui-tool-echo-hello.png" >}}
       {{< reuse-image-dark srcDark="img/agentgateway-ui-tool-echo-hello-dark.png" >}}
+{{< /version >}}
+{{< version include-if="1.2.x,1.1.x,1.0.x" >}}
+2. Connect to the MCP server with the agentgateway UI playground.
+
+   1. From the navigation menu, click [**Playground**](http://localhost:15000/ui/playground/).
+
+      {{< reuse-image src="img/1.2-earlier/agentgateway-ui-playground.png" >}}
+
+   2. In the **Testing** card, review your **Connection** details and click **Connect**. The agentgateway UI connects to the target that you configured and retrieves the tools that are exposed on the target.
+
+   3. Verify that you see a list of **Available Tools**.
+
+      {{< reuse-image src="img/1.2-earlier/ui-playground-tools.png" >}}
+
+3. Verify access to a tool.
+   1. From the **Available Tools** list, select the `echo` tool.
+   2. In the **Message** field, enter any string, such as `hello world`, and click **Run Tool**.
+   3. Verify that you see your message echoed in the **Response** card.
+
+      {{< reuse-image src="img/1.2-earlier/agentgateway-ui-tool-echo-hello.png" >}}
+{{< /version >}}
 
 4. Open the [Jaeger UI](http://localhost:16686). 
 
@@ -181,58 +203,68 @@ You can optionally enrich the traces that are captured by the agentgateway with 
    ```json
    cat <<EOF > ./config.json
    {
-     "gateways": {
-       "default": {
-         "port": 3000,
-         "protocol": "HTTP"
-       }
-     },
-     "routes": [
+     "binds": [
        {
-         "matches": [
+         "port": 3000,
+         "listeners": [
            {
-             "path": {
-               "pathPrefix": "/"
-             }
-           }
-         ],
-         "policies": {
-           "jwtAuth": {
-             "issuer": "me",
-             "audiences": ["me.com"],
-             "jwks": {
-               "file": "./pub-key"
-             }
-           }
-         },
-         "backends": [
-           {
-             "mcp": {
-               "targets": [
-                 {
-                   "name": "everything",
-                   "stdio": {
-                     "cmd": "npx",
-                     "args": [
-                       "@modelcontextprotocol/server-everything"
-                     ]
+             "name": "sse",
+             "protocol": "HTTP",
+             "hostname": null,
+             "routes": [
+               {
+                 "name": null,
+                 "ruleName": null,
+                 "hostnames": [],
+                 "matches": [
+                   {
+                     "path": {
+                       "pathPrefix": "/"
+                     }
                    }
-                 }
-               ]
-             }
+                 ],
+                 "policies": {
+                   "jwtAuth": {
+                     "issuer": "me",
+                     "audiences": ["me.com"],
+                     "jwks": {
+                       "file": "./pub-key"
+                     }
+                   }
+                 },
+                 "backends": [
+                   {
+                     "mcp": {
+                       "targets": [
+                         {
+                           "name": "everything",
+                           "stdio": {
+                             "cmd": "npx",
+                             "args": [
+                               "@modelcontextprotocol/server-everything"
+                             ]
+                           }
+                         }
+                       ]
+                     }
+                   }
+                 ]
+               }
+             ],
+             "tls": null
            }
          ]
        }
      ],
-     "frontendPolicies": {
-       "tracing": {
-         "host": "localhost:4317",
-         "protocol": "grpc",
-         "randomSampling": "1.0",
-         "attributes": {
-           "user": "jwt.sub",
-           "custom-tag": "\"test\""
+     "tracing": {
+       "tracer": {
+         "otlp": {
+           "endpoint": "http://localhost:4317"
          }
+       },
+       "tags": {
+         "user": "@sub",
+         "custom-tag": "test"
        }
      }
    }

--- a/assets/agw-docs/pages/operations/trace-requests-standalone-13x.md
+++ b/assets/agw-docs/pages/operations/trace-requests-standalone-13x.md
@@ -34,14 +34,14 @@ If you do not already have a setup, the following minimal `config.yaml` works fo
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-gateways:
-  default:
-    port: 3000
-    protocol: HTTP
-routes:
-- name: httpbin
-  backends:
-  - host: 127.0.0.1:8000
+binds:
+- port: 3000
+  listeners:
+  - protocol: HTTP
+    routes:
+    - name: httpbin
+      backends:
+      - host: 127.0.0.1:8000
 ```
 
 {{< doc-test paths="trace-validate" >}}
@@ -49,14 +49,14 @@ routes:
 {{< reuse "agw-docs/snippets/install-agentgateway-binary.md" >}}
 
 cat > /tmp/agctl-trace-config.yaml << 'EOF'
-gateways:
-  default:
-    port: 3000
-    protocol: HTTP
-routes:
-- name: httpbin
-  backends:
-  - host: 127.0.0.1:8000
+binds:
+- port: 3000
+  listeners:
+  - protocol: HTTP
+    routes:
+    - name: httpbin
+      backends:
+      - host: 127.0.0.1:8000
 EOF
 agentgateway -f /tmp/agctl-trace-config.yaml --validate-only
 {{< /doc-test >}}

--- a/assets/agw-docs/snippets/policy-apply-13x.md
+++ b/assets/agw-docs/snippets/policy-apply-13x.md
@@ -1,9 +1,9 @@
 The guides in this section show example configuration for different types of policies. Policies are applied to routes, which are part of a listener on a bind.
 
 ```yaml
-gateways:
-  default:
-    port: 3000
-routes:
-- policies:
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - policies:
 ```

--- a/assets/agw-docs/standalone/deployment/helm-13x.md
+++ b/assets/agw-docs/standalone/deployment/helm-13x.md
@@ -101,7 +101,7 @@ Open <http://localhost:15000/ui> to get started.
 
 ## Customize the configuration
 
-The chart bootstraps `/config/config.yaml` on first install. By default, the bootstrap configuration enables the admin UI on `0.0.0.0:15000`, uses SQLite at `/config/data.db`, and creates empty gateways for ports `8080` and `8443`.
+The chart bootstraps `/config/config.yaml` on first install. By default, the bootstrap configuration enables the admin UI on `0.0.0.0:15000`, uses SQLite at `/config/data.db`, and creates empty HTTP and HTTPS binds for ports `8080` and `8443`.
 
 Use the admin UI to add and save configuration updates after you install the chart. Throughout the rest of the standalone docs, whenever you see instructions to edit the configuration file, you can make the same change in the UI.
 
@@ -113,12 +113,11 @@ config:
     adminAddr: 0.0.0.0:15000
     database:
       url: sqlite:///config/data.db
-  gateways:
-    default:
-      port: 8080
-    secondary:
-      port: 8443
-  routes: []
+  binds:
+  - port: 8080
+    listeners: []
+  - port: 8443
+    listeners: []
 ```
 
 ```yaml
@@ -127,12 +126,11 @@ configYaml: |
     adminAddr: 0.0.0.0:15000
     database:
       url: sqlite:///config/data.db
-  gateways:
-    default:
-      port: 8080
-    secondary:
-      port: 8443
-  routes: []
+  binds:
+  - port: 8080
+    listeners: []
+  - port: 8443
+    listeners: []
 ```
 
 The chart does not overwrite an existing `/config/config.yaml` by default. To force Helm upgrades to rewrite the file from chart values, set `configBootstrap.overwrite=true`.

--- a/assets/agw-docs/standalone/quickstart/non-agentic-http-13x.md
+++ b/assets/agw-docs/standalone/quickstart/non-agentic-http-13x.md
@@ -68,7 +68,37 @@ Example output:
 
 ### Step 2: Configure agentgateway to route to httpbin
 
-You add the gateway and route from the UI, so you can start agentgateway without a config file. When you run `agentgateway` without specifying a config, it bootstraps a basic config at `~/.config/agentgateway/config.yaml` and uses it automatically.
+{{< version include-if="1.2.x,1.1.x,1.0.x" >}}
+Create a `config.yaml` that listens on port 3000 and routes traffic to the httpbin host. Use a static `host` backend with the address and port where httpbin is reachable, such as `127.0.0.1:8000`.
+
+```yaml {paths="httpbin"}
+cat > config.yaml << 'EOF'
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+binds:
+- port: 3000
+  listeners:
+  - protocol: HTTP
+    routes:
+    - backends:
+      - host: 127.0.0.1:8000
+EOF
+```
+
+In a separate terminal, run agentgateway with the config file.
+
+```sh
+agentgateway -f config.yaml
+```
+
+{{< doc-test paths="httpbin" >}}
+agentgateway -f config.yaml &
+AGW_PID=$!
+trap 'kill $AGW_PID 2>/dev/null' EXIT
+sleep 3
+{{< /doc-test >}}
+{{< /version >}}
+{{< version exclude-if="1.2.x,1.1.x,1.0.x" >}}
+You add the listener and route from the UI, so you can start agentgateway without a config file. When you run `agentgateway` without specifying a config, it bootstraps a basic config at `~/.config/agentgateway/config.yaml` and uses it automatically.
 
 1. In a separate terminal, start agentgateway.
 
@@ -78,13 +108,14 @@ You add the gateway and route from the UI, so you can start agentgateway without
 
 2. Open the [agentgateway UI](http://localhost:15000/ui/). On the **Gateway Overview**, find the **Traffic** row and click **Enable Traffic**.
 
-3. Add a gateway.
-   1. In the **Traffic** section of the navigation menu, click **Gateways**.
-   2. Click **Add gateway**, enter `default` for the **Name** and `3000` for the **Port**, and click **Save gateway**.
+3. Add a bind and listener.
+   1. In the **Traffic** section of the navigation menu, click **Listeners**.
+   2. Click **Add bind**, enter `3000` for the **Port**, and click **Save bind**.
+   3. Click **Add listener**, keep the defaults (HTTP, hostname `*`), and save the listener.
 
 4. Add a route to httpbin.
    1. Click **Routes**, and then click **Add route**.
-   2. For the **Gateway**, select the `default` gateway you created.
+   2. For the **Listener**, select the `:3000` listener you created.
    3. Under **Backends**, click **Add backend**, keep the **Host** target type, and enter `127.0.0.1:8000` for the host.
    4. Click **Save route**.
 
@@ -92,24 +123,25 @@ You add the gateway and route from the UI, so you can start agentgateway without
    {{< reuse-image-dark srcDark="img/ui-traffic-add-route-dark.png" >}}
 
 {{< doc-test paths="httpbin" >}}
-# Hidden test: the UI steps above (Enable Traffic -> Add gateway/route) are not
+# Hidden test: the UI steps above (Enable Traffic -> Add bind/listener/route) are not
 # scriptable, so this block reproduces the equivalent config they produce, to keep the
 # resulting setup tested.
 cat > config.yaml << 'EOF'
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-gateways:
-  default:
-    port: 3000
-    protocol: HTTP
-routes:
-- backends:
-  - host: 127.0.0.1:8000
+binds:
+- port: 3000
+  listeners:
+  - protocol: HTTP
+    routes:
+    - backends:
+      - host: 127.0.0.1:8000
 EOF
 agentgateway -f config.yaml &
 AGW_PID=$!
 trap 'kill $AGW_PID 2>/dev/null' EXIT
 sleep 3
 {{< /doc-test >}}
+{{< /version >}}
 
 ### Step 3: Send a request through agentgateway
 

--- a/content/docs/standalone/1.2.x/configuration/policies/conditional-policies.md
+++ b/content/docs/standalone/1.2.x/configuration/policies/conditional-policies.md
@@ -5,4 +5,4 @@ description: Run different variants of a policy on the same route based on a CEL
 test: skip
 ---
 
-{{< reuse "agw-docs/pages/conditional-policies.md" >}}
+{{< reuse "agw-docs/pages/conditional-policies-13x.md" >}}

--- a/content/docs/standalone/1.2.x/configuration/resiliency/_index.md
+++ b/content/docs/standalone/1.2.x/configuration/resiliency/_index.md
@@ -12,4 +12,4 @@ Simulate failures, disruptions, and adverse conditions to test that your gateway
 > [!TIP]
 > {{< reuse "agw-docs/snippets/policies-gateway-api.md" >}}
 
-{{< reuse "agw-docs/snippets/policy-apply.md" >}}
+{{< reuse "agw-docs/snippets/policy-apply-13x.md" >}}

--- a/content/docs/standalone/1.2.x/configuration/security/_index.md
+++ b/content/docs/standalone/1.2.x/configuration/security/_index.md
@@ -9,5 +9,5 @@ test: skip
 
 Secure backends and routes with different types of security, authentication, authorization, and rate limiting policies.
 
-{{< reuse "agw-docs/snippets/policy-apply.md" >}}
+{{< reuse "agw-docs/snippets/policy-apply-13x.md" >}}
 

--- a/content/docs/standalone/1.2.x/configuration/traffic-management/_index.md
+++ b/content/docs/standalone/1.2.x/configuration/traffic-management/_index.md
@@ -12,5 +12,5 @@ Control traffic and route requests through agentgateway.
 > [!TIP]
 > {{< reuse "agw-docs/snippets/policies-gateway-api.md" >}}
 
-{{< reuse "agw-docs/snippets/policy-apply.md" >}}
+{{< reuse "agw-docs/snippets/policy-apply-13x.md" >}}
 

--- a/content/docs/standalone/1.2.x/integrations/llm-clients/claude-code.md
+++ b/content/docs/standalone/1.2.x/integrations/llm-clients/claude-code.md
@@ -4,4 +4,4 @@ weight: 5
 description: Configure Claude Code CLI to use agentgateway
 ---
 
-{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md" >}}
+{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-code-13x.md" >}}

--- a/content/docs/standalone/1.2.x/integrations/llm-clients/claude-desktop.md
+++ b/content/docs/standalone/1.2.x/integrations/llm-clients/claude-desktop.md
@@ -4,4 +4,4 @@ weight: 6
 description: Configure Claude Desktop to use agentgateway
 ---
 
-{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-desktop.md" >}}
+{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-desktop-13x.md" >}}

--- a/content/docs/standalone/1.2.x/quickstart/non-agentic-http.md
+++ b/content/docs/standalone/1.2.x/quickstart/non-agentic-http.md
@@ -8,4 +8,4 @@ test:
     path: httpbin
 ---
 
-{{< reuse "agw-docs/standalone/quickstart/non-agentic-http.md" >}}
+{{< reuse "agw-docs/standalone/quickstart/non-agentic-http-13x.md" >}}

--- a/content/docs/standalone/1.2.x/reference/observability/traces.md
+++ b/content/docs/standalone/1.2.x/reference/observability/traces.md
@@ -4,4 +4,4 @@ weight: 20
 description: Configure distributed tracing with Jaeger and OpenTelemetry integration
 ---
 
-{{< reuse "agw-docs/pages/observability/traces.md" >}}
+{{< reuse "agw-docs/pages/observability/traces-13x.md" >}}

--- a/content/docs/standalone/latest/configuration/policies/conditional-policies.md
+++ b/content/docs/standalone/latest/configuration/policies/conditional-policies.md
@@ -5,4 +5,4 @@ description: Run different variants of a policy on the same route based on a CEL
 test: skip
 ---
 
-{{< reuse "agw-docs/pages/conditional-policies.md" >}}
+{{< reuse "agw-docs/pages/conditional-policies-13x.md" >}}

--- a/content/docs/standalone/latest/configuration/resiliency/_index.md
+++ b/content/docs/standalone/latest/configuration/resiliency/_index.md
@@ -12,4 +12,4 @@ Simulate failures, disruptions, and adverse conditions to test that your gateway
 > [!TIP]
 > {{< reuse "agw-docs/snippets/policies-gateway-api.md" >}}
 
-{{< reuse "agw-docs/snippets/policy-apply.md" >}}
+{{< reuse "agw-docs/snippets/policy-apply-13x.md" >}}

--- a/content/docs/standalone/latest/configuration/security/_index.md
+++ b/content/docs/standalone/latest/configuration/security/_index.md
@@ -9,5 +9,5 @@ test: skip
 
 Secure backends and routes with different types of security, authentication, authorization, and rate limiting policies.
 
-{{< reuse "agw-docs/snippets/policy-apply.md" >}}
+{{< reuse "agw-docs/snippets/policy-apply-13x.md" >}}
 

--- a/content/docs/standalone/latest/configuration/traffic-management/_index.md
+++ b/content/docs/standalone/latest/configuration/traffic-management/_index.md
@@ -12,4 +12,4 @@ Control traffic and route requests through agentgateway.
 > [!TIP]
 > {{< reuse "agw-docs/snippets/policies-gateway-api.md" >}}
 
-{{< reuse "agw-docs/snippets/policy-apply.md" >}}
+{{< reuse "agw-docs/snippets/policy-apply-13x.md" >}}

--- a/content/docs/standalone/latest/deployment/helm/_index.md
+++ b/content/docs/standalone/latest/deployment/helm/_index.md
@@ -5,4 +5,4 @@ description: Deploy standalone agentgateway on Kubernetes with Helm.
 test: skip
 ---
 
-{{< reuse "agw-docs/standalone/deployment/helm.md" >}}
+{{< reuse "agw-docs/standalone/deployment/helm-13x.md" >}}

--- a/content/docs/standalone/latest/integrations/llm-clients/claude-code.md
+++ b/content/docs/standalone/latest/integrations/llm-clients/claude-code.md
@@ -4,4 +4,4 @@ weight: 5
 description: Configure Claude Code CLI to use agentgateway
 ---
 
-{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-code.md" >}}
+{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-code-13x.md" >}}

--- a/content/docs/standalone/latest/integrations/llm-clients/claude-desktop.md
+++ b/content/docs/standalone/latest/integrations/llm-clients/claude-desktop.md
@@ -4,4 +4,4 @@ weight: 6
 description: Configure Claude Desktop to use agentgateway
 ---
 
-{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-desktop.md" >}}
+{{< reuse "agw-docs/pages/agentgateway/integrations/llm-clients/claude-desktop-13x.md" >}}

--- a/content/docs/standalone/latest/operations/trace-requests.md
+++ b/content/docs/standalone/latest/operations/trace-requests.md
@@ -12,4 +12,4 @@ test:
 {{< reuse "agw-docs/snippets/feature-experimental.md">}}
 {{< /callout >}}
 
-{{< reuse "agw-docs/pages/operations/trace-requests-standalone.md" >}}
+{{< reuse "agw-docs/pages/operations/trace-requests-standalone-13x.md" >}}

--- a/content/docs/standalone/latest/quickstart/non-agentic-http.md
+++ b/content/docs/standalone/latest/quickstart/non-agentic-http.md
@@ -8,4 +8,4 @@ test:
     path: httpbin
 ---
 
-{{< reuse "agw-docs/standalone/quickstart/non-agentic-http.md" >}}
+{{< reuse "agw-docs/standalone/quickstart/non-agentic-http-13x.md" >}}

--- a/content/docs/standalone/latest/reference/observability/traces.md
+++ b/content/docs/standalone/latest/reference/observability/traces.md
@@ -4,4 +4,4 @@ weight: 20
 description: Configure distributed tracing with Jaeger and OpenTelemetry integration
 ---
 
-{{< reuse "agw-docs/pages/observability/traces.md" >}}
+{{< reuse "agw-docs/pages/observability/traces-13x.md" >}}

--- a/content/docs/standalone/main/agent/a2a.md
+++ b/content/docs/standalone/main/agent/a2a.md
@@ -127,7 +127,7 @@ The agentgateway UI shows the listener and route that serve your A2A traffic. To
    {{< reuse-image-light src="img/ui-a2a-route.png" >}}
    {{< reuse-image-dark srcDark="img/ui-a2a-route-dark.png" >}}
 
-3. Click **Listeners** to review the bind and listener that serve A2A traffic on port 3000.
+3. Click **Gateways** to review the gateway that serves A2A traffic on port 3000.
 
    {{< reuse-image-light src="img/ui-a2a-listener.png" >}}
    {{< reuse-image-dark srcDark="img/ui-a2a-listener-dark.png" >}}

--- a/content/docs/standalone/main/configuration/_index.md
+++ b/content/docs/standalone/main/configuration/_index.md
@@ -2,7 +2,7 @@
 title: Configuration
 weight: 22
 icon: tune
-description: Entry point to configuring binds, listeners, routes, backends, and policies in agentgateway.
+description: Entry point to configuring gateways, listeners, routes, backends, and policies in agentgateway.
 test: skip
 ---
 

--- a/content/docs/standalone/main/configuration/backends.md
+++ b/content/docs/standalone/main/configuration/backends.md
@@ -1,6 +1,6 @@
 ---
 title: Backends
-weight: 13
+weight: 35
 description: Configure backends to route traffic to hostnames, LLM providers, and MCP servers.
 prev: /configuration/listeners
 test:

--- a/content/docs/standalone/main/configuration/backends.md
+++ b/content/docs/standalone/main/configuration/backends.md
@@ -21,20 +21,20 @@ export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
 
 ## Static Hosts
 
-The simplest form of backend is a static hostname or IP address. Static hosts are a routing-based backend, so they are configured under `binds`; the simplified `llm` and `mcp` modes model only LLM providers and MCP targets. For example:
+The simplest form of backend is a static hostname or IP address. Static hosts are a routing-based backend, so they are configured in a `routes` entry; the simplified `llm` and `mcp` modes model only LLM providers and MCP targets. For example:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - protocol: HTTP
-    routes:
-    - backends:
-      - host: example.com:8080
-        weight: 1
-      - host: 127.0.0.1:80
-        weight: 9
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes:
+- backends:
+  - host: example.com:8080
+    weight: 1
+  - host: 127.0.0.1:80
+    weight: 9
 ```
 
 {{< doc-test paths="backends" >}}
@@ -45,16 +45,16 @@ binds:
 #     reachable backends the page omits.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - protocol: HTTP
-    routes:
-    - backends:
-      - host: example.com:8080
-        weight: 1
-      - host: 127.0.0.1:80
-        weight: 9
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes:
+- backends:
+  - host: example.com:8080
+    weight: 1
+  - host: 127.0.0.1:80
+    weight: 9
 EOF
 agentgateway -f config.yaml --validate-only
 {{< /doc-test >}}
@@ -84,20 +84,20 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: stdio-server
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-          - name: http-server
-            mcp:
-              host: https://example.com/mcp
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: stdio-server
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+      - name: http-server
+        mcp:
+          host: https://example.com/mcp
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -105,26 +105,26 @@ binds:
 {{< doc-test paths="backends" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The MCP backend example (stdio + remote MCP targets) is accepted by
-#     agentgateway in both the routing-based (binds) and simplified MCP (mcp) forms.
+#     agentgateway in both the routing-based (gateways) and simplified MCP (mcp) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That the MCP targets actually start/connect at runtime — requires the npx
 #     command and remote server the page does not stand up.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: stdio-server
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-          - name: http-server
-            mcp:
-              host: https://example.com/mcp
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: stdio-server
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+      - name: http-server
+        mcp:
+          host: https://example.com/mcp
 EOF
 agentgateway -f config2.yaml --validate-only
 
@@ -166,19 +166,19 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          statefulMode: stateless
-          targets:
-          - name: openapi-server
-            openapi:
-              host: petstore3.swagger.io:443
-              schema:
-                url: https://petstore3.swagger.io/api/v3/openapi.json
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      statefulMode: stateless
+      targets:
+      - name: openapi-server
+        openapi:
+          host: petstore3.swagger.io:443
+          schema:
+            url: https://petstore3.swagger.io/api/v3/openapi.json
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -186,25 +186,25 @@ binds:
 {{< doc-test paths="backends" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The stateless session-routing MCP backend example is accepted by agentgateway
-#     in both the routing-based (binds) and simplified MCP (mcp) forms.
+#     in both the routing-based (gateways) and simplified MCP (mcp) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That stateless wrapping actually occurs at runtime — requires the OpenAPI
 #     upstream and live MCP traffic the page omits.
 cat <<'EOF' > config3.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          statefulMode: stateless
-          targets:
-          - name: openapi-server
-            openapi:
-              host: petstore3.swagger.io:443
-              schema:
-                url: https://petstore3.swagger.io/api/v3/openapi.json
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      statefulMode: stateless
+      targets:
+      - name: openapi-server
+        openapi:
+          host: petstore3.swagger.io:443
+          schema:
+            url: https://petstore3.swagger.io/api/v3/openapi.json
 EOF
 agentgateway -f config3.yaml --validate-only
 
@@ -245,19 +245,19 @@ llm:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-3.5-turbo
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-3.5-turbo
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -271,19 +271,19 @@ binds:
 #     OPENAI_API_KEY and live LLM traffic the page omits.
 cat <<'EOF' > config4.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-3.5-turbo
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-3.5-turbo
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 EOF
 agentgateway -f config4.yaml --validate-only
 
@@ -302,7 +302,7 @@ agentgateway -f config4-simplified.yaml --validate-only
 
 ## AWS AgentCore
 
-The AWS backend routes requests to an [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) agent runtime. AgentCore is a routing-based backend, so it is configured under `binds`.
+The AWS backend routes requests to an [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) agent runtime. AgentCore is a routing-based backend, so it is configured in a `routes` entry.
 
 Agentgateway derives the connection details from the `agentRuntimeArn` value: requests are sent over TLS to the `bedrock-agentcore` endpoint in the runtime's AWS region, with the path set to the runtime's invocation endpoint. Agentgateway signs each request with AWS SigV4 by using the standard [AWS credential lookup](https://docs.aws.amazon.com/sdkref/latest/guide/access.html) from the environment.
 

--- a/content/docs/standalone/main/configuration/gateways.md
+++ b/content/docs/standalone/main/configuration/gateways.md
@@ -1,6 +1,6 @@
 ---
 title: Gateways
-weight: 11
+weight: 20
 description: Define named gateways that set up the ports and listeners where LLM, MCP, UI, and routing traffic enters agentgateway.
 prev: /configuration/overview
 next: /configuration/listeners
@@ -14,9 +14,8 @@ Gateways are the entry point to agentgateway. Each gateway is a named port that 
 
 Because everything attaches to a gateway by name, you can serve several features on one port, or expose the same routes on more than one port.
 
-{{< callout type="info" >}}
-Gateways replace the `binds` field. The `binds` field still works, but it is deprecated. For help converting an existing configuration, see [Migrate from binds](#migrate-from-binds).
-{{< /callout >}}
+> [!NOTE]
+> Gateways replace the `binds` field. The `binds` field still works, but it is deprecated. For help converting an existing configuration, see [Migrate from binds](#migrate-from-binds).
 
 {{< doc-test paths="gateways" >}}
 {{< reuse "agw-docs/snippets/install-agentgateway-binary.md" >}}
@@ -39,6 +38,55 @@ Agentgateway configuration has three layers.
 * **Routes** define how traffic that reaches a gateway is matched and forwarded. Routes are configured at the top level and attach to gateways by name, which is what lets one route serve several gateways.
 
 The `llm`, `mcp`, and `ui` sections attach to gateways the same way that routes do.
+
+The following diagram shows traffic flowing left to right through the three layers, for two gateways.
+
+* The `default` gateway on port 3000 sets no `listeners`, so it gets one implicit listener that serves all hostnames. You do not configure that listener; the dotted box marks it as implied.
+* The `web` gateway on port 8443 splits its port into two named listeners that serve different hostnames.
+* Routes and features attach by name in the last column. A route that names `web` is served by every listener under that gateway, so both `discrete` and `wildcard` forward to it. A route that names `web/discrete` is served by that one listener only.
+
+```mermaid
+flowchart LR
+    C(["Client<br/>traffic"]):::client
+
+    subgraph gw["gateways: where traffic enters"]
+        GD["default<br/>port 3000"]:::gateway
+        GW["web<br/>port 8443"]:::gateway
+    end
+
+    subgraph ls["listeners: split one port by hostname"]
+        LI["implicit listener<br/>all hostnames"]:::implicit
+        LD["discrete<br/>a.example.com"]:::listener
+        LW["wildcard<br/>*.example.com"]:::listener
+    end
+
+    subgraph at["routes and features: attach by name"]
+        RD["route<br/>gateways: [default]"]:::route
+        FE["llm / mcp / ui<br/>gateways: [default]"]:::feature
+        RA["route<br/>gateways: [web/discrete]"]:::route
+        RW["route<br/>gateways: [web]"]:::route
+    end
+
+    C --> GD
+    C --> GW
+    GD --> LI
+    GW --> LD
+    GW --> LW
+    LI --> RD
+    LI --> FE
+    LD --> RA
+    LD --> RW
+    LW --> RW
+
+    %% Stroke-only styling, so node text follows the light or dark page theme.
+    %% Border weight and dashes carry the meaning, not color alone.
+    classDef client stroke:#7734be,stroke-width:1px,stroke-dasharray:4 3;
+    classDef gateway stroke:#7734be,stroke-width:3px;
+    classDef listener stroke:#7734be,stroke-width:2px,stroke-dasharray:6 3;
+    classDef implicit stroke:#7734be,stroke-width:1px,stroke-dasharray:2 3;
+    classDef route stroke:#7734be,stroke-width:1px;
+    classDef feature stroke:#7734be,stroke-width:1px,stroke-dasharray:2 2;
+```
 
 ## Define a gateway {#define}
 
@@ -321,9 +369,8 @@ ui: {}
 
 By default, the UI is served only on the admin interface on `localhost:15000`. Setting the `ui` section serves it on a gateway instead.
 
-{{< callout type="warning" >}}
-Serving the UI on a gateway exposes it to anyone who can reach that port. Protect it with authentication, typically [OIDC]({{< link-hextra path="/configuration/security/oidc/" >}}), before you expose it outside of localhost.
-{{< /callout >}}
+> [!WARNING]
+> Serving the UI on a gateway exposes it to anyone who can reach that port. Protect it with authentication, typically [OIDC]({{< link-hextra path="/configuration/security/oidc/" >}}), before you expose it outside of localhost.
 
 {{< doc-test paths="gateways" >}}
 # WHAT THIS TEST VALIDATES:
@@ -509,6 +556,5 @@ To convert a configuration:
 
 If you configure agentgateway through the UI, the UI detects an existing `binds` configuration and offers a one-click migration to gateways.
 
-{{< callout type="info" >}}
-You can keep `binds` and `gateways` in the same file while you migrate, as long as they do not claim the same port.
-{{< /callout >}}
+> [!NOTE]
+> You can keep `binds` and `gateways` in the same file while you migrate, as long as they do not claim the same port.

--- a/content/docs/standalone/main/configuration/gateways.md
+++ b/content/docs/standalone/main/configuration/gateways.md
@@ -10,9 +10,11 @@ test:
     path: gateways
 ---
 
-Gateways are the entry point to agentgateway. Each gateway is a named port that agentgateway listens on, and the features that serve traffic attach to it: HTTP and TCP routes, LLM models, MCP targets, and the agentgateway UI.
+Gateways are the entry point to agentgateway. Each gateway is a named port that agentgateway listens on, and the endpoints that serve traffic attach to it: HTTP and TCP routes, LLM models, MCP targets, and the agentgateway UI.
 
-Because everything attaches to a gateway by name, you can serve several features on one port, or expose the same routes on more than one port.
+Every gateway has one or more listeners. A gateway that serves a single hostname needs only the implicit listener that it comes with, and a gateway that serves several hostnames on one port defines a named listener for each one.
+
+Because everything attaches to a gateway by name, you can serve several endpoints on one port, or expose the same routes on more than one port.
 
 > [!NOTE]
 > Gateways replace the `binds` field. The `binds` field still works, but it is deprecated. For help converting an existing configuration, see [Migrate from binds](#migrate-from-binds).
@@ -43,7 +45,7 @@ The following diagram shows traffic flowing left to right through the three laye
 
 * The `default` gateway on port 3000 sets no `listeners`, so it gets one implicit listener that serves all hostnames. You do not configure that listener; the dotted box marks it as implied.
 * The `web` gateway on port 8443 splits its port into two named listeners that serve different hostnames.
-* Routes and features attach by name in the last column. A route that names `web` is served by every listener under that gateway, so both `discrete` and `wildcard` forward to it. A route that names `web/discrete` is served by that one listener only.
+* Routes, LLM, MCP, and the UI attach by name in the last column. A route that names `web` is served by every listener under that gateway, so both `discrete` and `wildcard` forward to it. A route that names `web/discrete` is served by that one listener only.
 
 ```mermaid
 flowchart LR
@@ -60,9 +62,9 @@ flowchart LR
         LW["wildcard<br/>*.example.com"]:::listener
     end
 
-    subgraph at["routes and features: attach by name"]
+    subgraph at["routes and endpoints: attach by name"]
         RD["route<br/>gateways: [default]"]:::route
-        FE["llm / mcp / ui<br/>gateways: [default]"]:::feature
+        FE["llm / mcp / ui<br/>gateways: [default]"]:::endpoint
         RA["route<br/>gateways: [web/discrete]"]:::route
         RW["route<br/>gateways: [web]"]:::route
     end
@@ -85,7 +87,7 @@ flowchart LR
     classDef listener stroke:#7734be,stroke-width:2px,stroke-dasharray:6 3;
     classDef implicit stroke:#7734be,stroke-width:1px,stroke-dasharray:2 3;
     classDef route stroke:#7734be,stroke-width:1px;
-    classDef feature stroke:#7734be,stroke-width:1px,stroke-dasharray:2 2;
+    classDef endpoint stroke:#7734be,stroke-width:1px,stroke-dasharray:2 2;
 ```
 
 ## Define a gateway {#define}
@@ -342,7 +344,7 @@ agentgateway -f config5.yaml --validate-only
 
 ## Attach LLM, MCP, and the UI to a gateway {#features}
 
-The `llm`, `mcp`, and `ui` sections each take a `gateways` field, so you can serve them all from one port. Each feature serves its own paths: LLM uses the standard serving paths such as `/v1/chat/completions`, MCP uses `/mcp`, and the UI serves the remaining paths.
+The `llm`, `mcp`, and `ui` sections each take a `gateways` field, so you can serve them all from one port. Each section serves its own paths: LLM uses the standard serving paths such as `/v1/chat/completions`, MCP uses `/mcp`, and the UI serves the remaining paths.
 
 The following configuration exposes an LLM model, an MCP target, and the UI on port 3000. None of the three sections sets `gateways`, so all of them attach to the gateway named `default`.
 
@@ -377,7 +379,7 @@ By default, the UI is served only on the admin interface on `localhost:15000`. S
 #   * An LLM model, MCP target, and the UI attached to one gateway are accepted by
 #     agentgateway.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
-#   * That each feature serves its paths at runtime — requires a provider API key,
+#   * That each section serves its paths at runtime — requires a provider API key,
 #     an MCP server process, and a browser session the page does not exercise.
 export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
 cat <<'EOF' > config6.yaml
@@ -403,7 +405,7 @@ EOF
 agentgateway -f config6.yaml --validate-only
 {{< /doc-test >}}
 
-Because each feature attaches separately, you can also split them across ports. The following configuration serves the UI on its own port while LLM traffic stays on the shared gateway.
+Because each section attaches separately, you can also split them across ports. The following configuration serves the UI on its own port while LLM traffic stays on the shared gateway.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -426,7 +428,7 @@ ui:
 # WHAT THIS TEST VALIDATES:
 #   * Splitting the UI and LLM across two gateways is accepted by agentgateway.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
-#   * That each port serves the expected feature at runtime — requires a provider
+#   * That each port serves the expected section at runtime — requires a provider
 #     API key and a browser session the page does not exercise.
 export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
 cat <<'EOF' > config7.yaml
@@ -543,7 +545,7 @@ routes:
 
 To convert a configuration:
 
-1. Replace the `binds` list with a `gateways` map. Give each port a name, and name your primary gateway `default` so that routes and features attach to it without an explicit `gateways` field.
+1. Replace the `binds` list with a `gateways` map. Give each port a name, and name your primary gateway `default` so that routes and endpoints attach to it without an explicit `gateways` field.
 2. Move each bind's `port` to the gateway. If the bind had one listener, move that listener's `protocol`, `hostname`, and `tls` settings to the gateway too. If the bind had multiple listeners, keep them in the gateway's `listeners` field and give each one a `name`.
 3. Unwrap each listener's `policies` block. Gateways and listeners take policies as direct fields, so a policy that was at `binds[].listeners[].policies.jwtAuth` moves to `gateways.<name>.jwtAuth`. Route and backend policies keep their `policies` wrapper.
 4. Move `routes` and `tcpRoutes` to the top level. Add a `gateways` field to each route that names the gateway or the `<gateway-name>/<listener-name>` it serves.

--- a/content/docs/standalone/main/configuration/gateways.md
+++ b/content/docs/standalone/main/configuration/gateways.md
@@ -1,0 +1,514 @@
+---
+title: Gateways
+weight: 11
+description: Define named gateways that set up the ports and listeners where LLM, MCP, UI, and routing traffic enters agentgateway.
+prev: /configuration/overview
+next: /configuration/listeners
+test:
+  listeners:
+  - file: ${versionRoot}/configuration/gateways.md
+    path: gateways
+---
+
+Gateways are the entry point to agentgateway. Each gateway is a named port that agentgateway listens on, and the features that serve traffic attach to it: HTTP and TCP routes, LLM models, MCP targets, and the agentgateway UI.
+
+Because everything attaches to a gateway by name, you can serve several features on one port, or expose the same routes on more than one port.
+
+{{< callout type="info" >}}
+Gateways replace the `binds` field. The `binds` field still works, but it is deprecated. For help converting an existing configuration, see [Migrate from binds](#migrate-from-binds).
+{{< /callout >}}
+
+{{< doc-test paths="gateways" >}}
+{{< reuse "agw-docs/snippets/install-agentgateway-binary.md" >}}
+{{< /doc-test >}}
+
+{{< doc-test paths="gateways" >}}
+# Create self-signed certs referenced by the examples
+mkdir -p certs
+openssl req -x509 -newkey rsa:2048 -keyout certs/key.pem -out certs/cert.pem -days 365 -nodes -subj "/CN=localhost" 2>/dev/null
+openssl req -x509 -newkey rsa:2048 -keyout certs/key-a.pem -out certs/cert-a.pem -days 365 -nodes -subj "/CN=a.example.com" 2>/dev/null
+openssl req -x509 -newkey rsa:2048 -keyout certs/key-wildcard.pem -out certs/cert-wildcard.pem -days 365 -nodes -subj "/CN=wildcard.example.com" 2>/dev/null
+{{< /doc-test >}}
+
+## How gateways, listeners, and routes fit together {#concepts}
+
+Agentgateway configuration has three layers.
+
+* **Gateways** define where traffic enters. A gateway sets a port, and optionally a protocol and TLS settings. Gateways are configured as a map, so each one has a name that other sections reference.
+* **Listeners** optionally subdivide a gateway. Use listeners when one port must serve multiple hostnames with different TLS certificates. A gateway without listeners has a single implicit listener.
+* **Routes** define how traffic that reaches a gateway is matched and forwarded. Routes are configured at the top level and attach to gateways by name, which is what lets one route serve several gateways.
+
+The `llm`, `mcp`, and `ui` sections attach to gateways the same way that routes do.
+
+## Define a gateway {#define}
+
+Each key in the `gateways` map is the gateway name, and each gateway needs a `port`. The following configuration listens for HTTP traffic on port 3000 and forwards it to a backend on `localhost:8000`.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8000
+```
+
+The route in this example does not set a `gateways` field. When you omit that field, the route attaches to the gateway named `default`. Naming your primary gateway `default` keeps simple configurations short.
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * A minimal gateway with an implicitly attached route is accepted by agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That traffic reaches localhost:8000 at runtime — the backend does not exist
+#     in the test environment.
+cat <<'EOF' > config.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8000
+EOF
+agentgateway -f config.yaml --validate-only
+{{< /doc-test >}}
+
+## Attach routes to a gateway {#attach-routes}
+
+To attach a route to a specific gateway, list the gateway name in the route's `gateways` field. The following configuration serves two different sets of routes on two ports.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  public:
+    port: 8080
+  internal:
+    port: 8081
+routes:
+- name: public-api
+  gateways: [public]
+  matches:
+  - path:
+      pathPrefix: /api
+  backends:
+  - host: api.example.com:443
+- name: internal-admin
+  gateways: [internal]
+  matches:
+  - path:
+      pathPrefix: /admin
+  backends:
+  - host: admin.internal:8000
+```
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * Routes attached to two separately named gateways are accepted by agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That each route serves traffic on its own port at runtime — the backends do
+#     not exist in the test environment.
+cat <<'EOF' > config2.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  public:
+    port: 8080
+  internal:
+    port: 8081
+routes:
+- name: public-api
+  gateways: [public]
+  matches:
+  - path:
+      pathPrefix: /api
+  backends:
+  - host: api.example.com:443
+- name: internal-admin
+  gateways: [internal]
+  matches:
+  - path:
+      pathPrefix: /admin
+  backends:
+  - host: admin.internal:8000
+EOF
+agentgateway -f config2.yaml --validate-only
+{{< /doc-test >}}
+
+### Serve the same routes on multiple gateways {#multiple-gateways}
+
+Because routes attach by name, one route can serve several gateways. A common case is serving the same API on both plaintext HTTP and HTTPS.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  http:
+    port: 8080
+  https:
+    port: 8443
+    tls:
+      cert: ./certs/cert.pem
+      key: ./certs/key.pem
+routes:
+- name: api
+  gateways: [http, https]  # One route definition serves both ports
+  backends:
+  - host: api.example.com:443
+```
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * A single route attached to both an HTTP and an HTTPS gateway is accepted by
+#     agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That both ports serve the route at runtime — requires client requests and a
+#     backend the page does not exercise.
+cat <<'EOF' > config3.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  http:
+    port: 8080
+  https:
+    port: 8443
+    tls:
+      cert: ./certs/cert.pem
+      key: ./certs/key.pem
+routes:
+- name: api
+  gateways: [http, https]
+  backends:
+  - host: api.example.com:443
+EOF
+agentgateway -f config3.yaml --validate-only
+{{< /doc-test >}}
+
+## Add listeners to a gateway {#listeners}
+
+Use the `listeners` field when one port must serve multiple hostnames with different TLS certificates. Each listener takes a `name`, and routes reference it in the form `<gateway-name>/<listener-name>`.
+
+When you set `listeners`, `port` is the only other field you can set on the gateway itself. Move the protocol, hostname, and TLS settings into each listener.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  web:
+    port: 8443
+    listeners:
+    - name: discrete
+      hostname: a.example.com
+      tls:
+        cert: ./certs/cert-a.pem
+        key: ./certs/key-a.pem
+    - name: wildcard
+      hostname: "*.example.com"
+      tls:
+        cert: ./certs/cert-wildcard.pem
+        key: ./certs/key-wildcard.pem
+routes:
+- name: a-only
+  gateways: [web/discrete]  # Serves a.example.com only
+  backends:
+  - host: a-backend.example.com:443
+- name: everything-else
+  gateways: [web]  # Serves every listener under the web gateway
+  backends:
+  - host: shared-backend.example.com:443
+```
+
+All listeners under a gateway share the gateway's port, so they cannot mix encrypted and plaintext traffic. If you need both HTTP and HTTPS, define two gateways as shown in [Serve the same routes on multiple gateways](#multiple-gateways).
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * A gateway with two named SNI listeners, and routes attached to one listener
+#     and to the whole gateway, is accepted by agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That SNI selects the right certificate and listener at runtime — requires TLS
+#     client connections the page does not exercise.
+cat <<'EOF' > config4.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  web:
+    port: 8443
+    listeners:
+    - name: discrete
+      hostname: a.example.com
+      tls:
+        cert: ./certs/cert-a.pem
+        key: ./certs/key-a.pem
+    - name: wildcard
+      hostname: "*.example.com"
+      tls:
+        cert: ./certs/cert-wildcard.pem
+        key: ./certs/key-wildcard.pem
+routes:
+- name: a-only
+  gateways: [web/discrete]
+  backends:
+  - host: a-backend.example.com:443
+- name: everything-else
+  gateways: [web]
+  backends:
+  - host: shared-backend.example.com:443
+EOF
+agentgateway -f config4.yaml --validate-only
+{{< /doc-test >}}
+
+## Set the gateway protocol {#protocol}
+
+The `protocol` field controls whether a gateway accepts HTTP routes or TCP routes. Valid values are `HTTP`, `HTTPS`, `TCP`, and `TLS`. When you omit the field, a gateway defaults to `HTTP`, or to `HTTPS` when you set `tls`.
+
+TCP and TLS gateways serve `tcpRoutes` instead of `routes`.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  tcp:
+    port: 9000
+    protocol: TCP
+tcpRoutes:
+- gateways: [tcp]
+  backends:
+  - host: localhost:8000
+```
+
+For more information about each protocol, including TLS termination and passthrough, see [Listeners]({{< link-hextra path="/configuration/listeners/" >}}).
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * A TCP gateway with an attached tcpRoute is accepted by agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That TCP traffic is forwarded at runtime — the backend does not exist in the
+#     test environment.
+cat <<'EOF' > config5.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  tcp:
+    port: 9000
+    protocol: TCP
+tcpRoutes:
+- gateways: [tcp]
+  backends:
+  - host: localhost:8000
+EOF
+agentgateway -f config5.yaml --validate-only
+{{< /doc-test >}}
+
+## Attach LLM, MCP, and the UI to a gateway {#features}
+
+The `llm`, `mcp`, and `ui` sections each take a `gateways` field, so you can serve them all from one port. Each feature serves its own paths: LLM uses the standard serving paths such as `/v1/chat/completions`, MCP uses `/mcp`, and the UI serves the remaining paths.
+
+The following configuration exposes an LLM model, an MCP target, and the UI on port 3000. None of the three sections sets `gateways`, so all of them attach to the gateway named `default`.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+llm:
+  models:
+  - name: "*"
+    provider: openAI
+    params:
+      apiKey: "$OPENAI_API_KEY"
+mcp:
+  targets:
+  - name: everything
+    stdio:
+      cmd: npx
+      args:
+      - '@modelcontextprotocol/server-everything'
+ui: {}
+```
+
+By default, the UI is served only on the admin interface on `localhost:15000`. Setting the `ui` section serves it on a gateway instead.
+
+{{< callout type="warning" >}}
+Serving the UI on a gateway exposes it to anyone who can reach that port. Protect it with authentication, typically [OIDC]({{< link-hextra path="/configuration/security/oidc/" >}}), before you expose it outside of localhost.
+{{< /callout >}}
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * An LLM model, MCP target, and the UI attached to one gateway are accepted by
+#     agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That each feature serves its paths at runtime — requires a provider API key,
+#     an MCP server process, and a browser session the page does not exercise.
+export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
+cat <<'EOF' > config6.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+llm:
+  models:
+  - name: "*"
+    provider: openAI
+    params:
+      apiKey: "$OPENAI_API_KEY"
+mcp:
+  targets:
+  - name: everything
+    stdio:
+      cmd: npx
+      args:
+      - '@modelcontextprotocol/server-everything'
+ui: {}
+EOF
+agentgateway -f config6.yaml --validate-only
+{{< /doc-test >}}
+
+Because each feature attaches separately, you can also split them across ports. The following configuration serves the UI on its own port while LLM traffic stays on the shared gateway.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+  admin:
+    port: 9000
+llm:
+  models:
+  - name: "*"
+    provider: openAI
+    params:
+      apiKey: "$OPENAI_API_KEY"
+ui:
+  gateways: [admin]
+```
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * Splitting the UI and LLM across two gateways is accepted by agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That each port serves the expected feature at runtime — requires a provider
+#     API key and a browser session the page does not exercise.
+export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
+cat <<'EOF' > config7.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+  admin:
+    port: 9000
+llm:
+  models:
+  - name: "*"
+    provider: openAI
+    params:
+      apiKey: "$OPENAI_API_KEY"
+ui:
+  gateways: [admin]
+EOF
+agentgateway -f config7.yaml --validate-only
+{{< /doc-test >}}
+
+## Attach policies to a gateway {#policies}
+
+Gateways and listeners accept the same policies that listeners accepted under `binds`, such as `jwtAuth`, `authorization`, `cors`, `basicAuth`, `apiKey`, `oidc`, `extAuthz`, `extProc`, and `transformations`. A policy on a gateway applies to all traffic that enters that gateway, including LLM, MCP, and UI traffic.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+    cors:  # Applies to every route on this gateway
+      allowOrigins:
+      - "https://app.example.com"
+      allowMethods:
+      - GET
+      - POST
+routes:
+- backends:
+  - host: localhost:8000
+```
+
+To scope a policy more narrowly, attach it to a listener or to a route instead. For more information, see [Attachment points]({{< link-hextra path="/configuration/policies/attachment/" >}}).
+
+{{< doc-test paths="gateways" >}}
+# WHAT THIS TEST VALIDATES:
+#   * A CORS policy attached to a gateway is accepted by agentgateway.
+# WHAT THIS TEST DOES NOT VALIDATE (and why):
+#   * That CORS headers are applied at runtime — requires a preflight request the
+#     page does not exercise.
+cat <<'EOF' > config8.yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+    cors:
+      allowOrigins:
+      - "https://app.example.com"
+      allowMethods:
+      - GET
+      - POST
+routes:
+- backends:
+  - host: localhost:8000
+EOF
+agentgateway -f config8.yaml --validate-only
+{{< /doc-test >}}
+
+## Migrate from binds {#migrate-from-binds}
+
+The `binds` field nests listeners and routes inside each port, which means a route belongs to exactly one listener. Gateways invert that relationship: routes are top level and reference gateways by name.
+
+| Concept | `binds` | `gateways` |
+|---------|---------|------------|
+| Port | An entry in the `binds` list | A named entry in the `gateways` map |
+| Listener | `binds[].listeners[]` | `gateways.<name>.listeners[]`, or the gateway itself |
+| HTTP routes | Nested under `binds[].listeners[].routes` | Top-level `routes`, attached with `gateways` |
+| TCP routes | Nested under `binds[].listeners[].tcpRoutes` | Top-level `tcpRoutes`, attached with `gateways` |
+| Reuse across ports | Duplicate the route under each listener | List several gateways in one route |
+| LLM, MCP, and UI on the same port as routes | Not supported | Attach each section to the same gateway |
+
+The following configuration uses `binds`.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+binds:
+- port: 3000
+  listeners:
+  - protocol: HTTP
+    routes:
+    - name: api
+      matches:
+      - path:
+          pathPrefix: /api
+      backends:
+      - host: localhost:8000
+```
+
+The following configuration is the equivalent with `gateways`.
+
+```yaml
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes:
+- name: api
+  matches:
+  - path:
+      pathPrefix: /api
+  backends:
+  - host: localhost:8000
+```
+
+To convert a configuration:
+
+1. Replace the `binds` list with a `gateways` map. Give each port a name, and name your primary gateway `default` so that routes and features attach to it without an explicit `gateways` field.
+2. Move each bind's `port` to the gateway. If the bind had one listener, move that listener's `protocol`, `hostname`, and `tls` settings to the gateway too. If the bind had multiple listeners, keep them in the gateway's `listeners` field and give each one a `name`.
+3. Unwrap each listener's `policies` block. Gateways and listeners take policies as direct fields, so a policy that was at `binds[].listeners[].policies.jwtAuth` moves to `gateways.<name>.jwtAuth`. Route and backend policies keep their `policies` wrapper.
+4. Move `routes` and `tcpRoutes` to the top level. Add a `gateways` field to each route that names the gateway or the `<gateway-name>/<listener-name>` it serves.
+5. Replace deprecated `llm.port`, `llm.tls`, and `mcp.port` settings with a gateway that the `llm` and `mcp` sections attach to.
+6. Validate the result before you run it.
+
+   ```shell
+   agentgateway -f config.yaml --validate-only
+   ```
+
+If you configure agentgateway through the UI, the UI detects an existing `binds` configuration and offers a one-click migration to gateways.
+
+{{< callout type="info" >}}
+You can keep `binds` and `gateways` in the same file while you migrate, as long as they do not claim the same port.
+{{< /callout >}}

--- a/content/docs/standalone/main/configuration/listeners.md
+++ b/content/docs/standalone/main/configuration/listeners.md
@@ -1,6 +1,6 @@
 ---
 title: Listeners
-weight: 12
+weight: 25
 description: Define the ports, protocols, and TLS settings where agentgateway accepts incoming traffic.
 test:
   listeners:

--- a/content/docs/standalone/main/configuration/listeners.md
+++ b/content/docs/standalone/main/configuration/listeners.md
@@ -11,7 +11,7 @@ test:
 Listeners are the entrypoints for traffic into agentgateway.
 Agentgateway supports both {{< gloss "HTTP (Hypertext Transfer Protocol)" >}}HTTP{{< /gloss >}} and {{< gloss "TCP (Transmission Control Protocol)" >}}TCP{{< /gloss >}} traffic, with and without {{< gloss "TLS (Transport Layer Security)" >}}TLS{{< /gloss >}}.
 
-The following examples use routing-based configuration with `binds`. If you only route to LLM or MCP backends, the simplified `llm` and `mcp` modes set the listener port and TLS directly through `llm.port`, `llm.tls`, and `mcp.port`. For more information about the configuration styles, see [Routing-based configuration]({{< link-hextra path="/llm/configuration-modes/" >}}).
+You configure a listener as part of a gateway. A gateway with a single listener sets the protocol and TLS settings directly, and a gateway that serves multiple hostnames on one port uses the `listeners` field to define each one. For more information about gateways and how routes attach to them, see [Gateways]({{< link-hextra path="/configuration/gateways/" >}}).
 
 {{< doc-test paths="listeners" >}}
 {{< reuse "agw-docs/snippets/install-agentgateway-binary.md" >}}
@@ -29,17 +29,17 @@ cp examples/tls/certs/key.pem certs/key.pem
 
 ## HTTP Listeners
 
-An HTTP listener can be configured by setting `protocol: HTTP` in the listener configuration.
+An HTTP listener can be configured by setting `protocol: HTTP` on the gateway.
 This is also the default protocol if no protocol is specified.
 
 For example:
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - protocol: HTTP
-    routes: []
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes: []
 ```
 
 {{< doc-test paths="listeners" >}}
@@ -50,29 +50,29 @@ binds:
 #     no routes or backends to exercise.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - protocol: HTTP
-    routes: []
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes: []
 EOF
 agentgateway -f config.yaml --validate-only
 {{< /doc-test >}}
 
 ## HTTPS Listeners
 
-Serving {{< gloss "HTTPS (HTTP Secure)" >}}HTTPS{{< /gloss >}} traffic requires TLS certificates and setting `protocol: HTTPS` in the listener configuration:
+Serving {{< gloss "HTTPS (HTTP Secure)" >}}HTTPS{{< /gloss >}} traffic requires TLS certificates and setting `protocol: HTTPS` on the gateway. When you set `tls`, the protocol defaults to `HTTPS`, so you can also omit the `protocol` field.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 443
-  listeners:
-  - protocol: HTTPS
+gateways:
+  default:
+    port: 443
+    protocol: HTTPS
     tls:
       cert: examples/tls/certs/cert.pem
       key: examples/tls/certs/key.pem
-    routes: []
+routes: []
 ```
 
 {{< doc-test paths="listeners" >}}
@@ -83,14 +83,14 @@ binds:
 #     the page does not exercise.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 443
-  listeners:
-  - protocol: HTTPS
+gateways:
+  default:
+    port: 443
+    protocol: HTTPS
     tls:
       cert: examples/tls/certs/cert.pem
       key: examples/tls/certs/key.pem
-    routes: []
+routes: []
 EOF
 agentgateway -f config2.yaml --validate-only
 {{< /doc-test >}}
@@ -102,29 +102,31 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -node
 ```
 
 By default, a listener will match any traffic on the port.
-Requests can be routed based on the [hostname](https://en.wikipedia.org/wiki/Server_Name_Indication) using the `hostname` field.
+To serve multiple hostnames on one port, add a named listener for each one under the gateway's `listeners` field and set the `hostname` field. Traffic is then routed based on the [hostname](https://en.wikipedia.org/wiki/Server_Name_Indication).
 The most exact match will be used, as well as the corresponding TLS certificates.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 443
-  listeners:
-  - name: discrete
-    protocol: HTTPS
-    hostname: a.example.com
-    tls:
-      cert: examples/tls/certs/cert-a.pem
-      key: examples/tls/certs/key-a.pem
-    routes: []
-  - name: wildcard
-    protocol: HTTPS
-    hostname: "*.example.com"
-    tls:
-      cert: examples/tls/certs/cert-wildcard.pem
-      key: examples/tls/certs/key-wildcard.pem
-    routes: []
+gateways:
+  web:
+    port: 443
+    listeners:
+    - name: discrete
+      protocol: HTTPS
+      hostname: a.example.com
+      tls:
+        cert: examples/tls/certs/cert-a.pem
+        key: examples/tls/certs/key-a.pem
+    - name: wildcard
+      protocol: HTTPS
+      hostname: "*.example.com"
+      tls:
+        cert: examples/tls/certs/cert-wildcard.pem
+        key: examples/tls/certs/key-wildcard.pem
+routes: []
 ```
+
+To attach a route to one of these listeners instead of the whole gateway, reference it as `web/discrete` or `web/wildcard` in the route's `gateways` field.
 
 {{< doc-test paths="listeners" >}}
 # WHAT THIS TEST VALIDATES:
@@ -134,82 +136,80 @@ binds:
 #     client connections the page does not exercise.
 cat <<'EOF' > config3.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 443
-  listeners:
-  - name: discrete
-    protocol: HTTPS
-    hostname: a.example.com
-    tls:
-      cert: examples/tls/certs/cert-a.pem
-      key: examples/tls/certs/key-a.pem
-    routes: []
-  - name: wildcard
-    protocol: HTTPS
-    hostname: "*.example.com"
-    tls:
-      cert: examples/tls/certs/cert-wildcard.pem
-      key: examples/tls/certs/key-wildcard.pem
-    routes: []
+gateways:
+  web:
+    port: 443
+    listeners:
+    - name: discrete
+      protocol: HTTPS
+      hostname: a.example.com
+      tls:
+        cert: examples/tls/certs/cert-a.pem
+        key: examples/tls/certs/key-a.pem
+    - name: wildcard
+      protocol: HTTPS
+      hostname: "*.example.com"
+      tls:
+        cert: examples/tls/certs/cert-wildcard.pem
+        key: examples/tls/certs/key-wildcard.pem
+routes: []
 EOF
 agentgateway -f config3.yaml --validate-only
 {{< /doc-test >}}
 
 ### Redirect HTTP to HTTPS
 
-To serve both HTTP and HTTPS, configure an HTTP listener that redirects all traffic to the HTTPS listener with a `requestRedirect` policy. The following example listens for plaintext HTTP on port 80 and redirects it to HTTPS, while serving encrypted traffic on port 443.
+Listeners under one gateway share a port, so they cannot mix encrypted and plaintext traffic. To serve both HTTP and HTTPS, define a separate gateway for each, and attach a route with a `requestRedirect` policy to the HTTP gateway. The following example listens for plaintext HTTP on port 80 and redirects it to HTTPS, while serving encrypted traffic on port 443.
 
 ```yaml
-binds:
-- port: 80
-  listeners:
-  - name: http
+gateways:
+  http:
+    port: 80
     protocol: HTTP
-    routes:
-    - policies:
-        requestRedirect:
-          scheme: https
-- port: 443
-  listeners:
-  - name: https
+  https:
+    port: 443
     protocol: HTTPS
     tls:
       cert: ./certs/cert.pem
       key: ./certs/key.pem
-    routes: []
+routes:
+- name: redirect
+  gateways: [http]  # Redirects plaintext traffic to the https gateway
+  policies:
+    requestRedirect:
+      scheme: https
 ```
 
 {{< doc-test paths="listeners" >}}
 # WHAT THIS TEST VALIDATES:
-#   * The "Redirect HTTP to HTTPS" example config (HTTP requestRedirect + HTTPS listener) is accepted by agentgateway.
+#   * The "Redirect HTTP to HTTPS" example config (HTTP requestRedirect + HTTPS gateway) is accepted by agentgateway.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That an HTTP request is actually redirected to HTTPS at runtime — requires a
 #     client request the page does not exercise.
 cat <<'EOF' > config4.yaml
-binds:
-- port: 80
-  listeners:
-  - name: http
+gateways:
+  http:
+    port: 80
     protocol: HTTP
-    routes:
-    - policies:
-        requestRedirect:
-          scheme: https
-- port: 443
-  listeners:
-  - name: https
+  https:
+    port: 443
     protocol: HTTPS
     tls:
       cert: ./certs/cert.pem
       key: ./certs/key.pem
-    routes: []
+routes:
+- name: redirect
+  gateways: [http]
+  policies:
+    requestRedirect:
+      scheme: https
 EOF
 agentgateway -f config4.yaml --validate-only
 {{< /doc-test >}}
 
 ## TCP Listeners
 
-TCP listeners can be configured by setting `protocol: TCP` in the listener configuration.
+TCP listeners can be configured by setting `protocol: TCP` on the gateway.
 TCP listeners are useful when serving traffic that is not HTTP based.
 
 > [!NOTE]
@@ -217,12 +217,11 @@ TCP listeners are useful when serving traffic that is not HTTP based.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 9000
-  listeners:
-  - name: default
+gateways:
+  tcp:
+    port: 9000
     protocol: TCP
-    tcpRoutes: []
+tcpRoutes: []
 ```
 
 {{< doc-test paths="listeners" >}}
@@ -233,38 +232,16 @@ binds:
 #     tcpRoutes or backends to exercise.
 cat <<'EOF' > config5.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 9000
-  listeners:
-  - name: default
+gateways:
+  tcp:
+    port: 9000
     protocol: TCP
-    tcpRoutes: []
+tcpRoutes: []
 EOF
 agentgateway -f config5.yaml --validate-only
 {{< /doc-test >}}
 
 Additionally, note the use of `tcpRoutes` instead of `routes` (which are HTTP routes) in the example.
-
-## Auto-detect protocol
-
-Set `protocol: auto` to automatically detect the protocol for each incoming connection. The gateway peeks at the first byte of the connection. If the byte is `0x16` (a TLS ClientHello), the gateway dispatches the connection as TLS. Otherwise, the gateway dispatches it as HTTP. Use auto-detection in mixed-protocol environments where the same port accepts both TLS and plaintext traffic.
-
-```yaml
-# yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 443
-  listeners:
-  - protocol: auto
-    routes: []
-    tls:
-      cert: examples/tls/certs/cert.pem
-      key: examples/tls/certs/key.pem
-```
-
-<!-- NOTE: The `protocol: auto` example above is intentionally NOT covered by a doc test.
-     The current agentgateway binary rejects `auto` (valid protocols: HTTP, HTTPS, TLS, TCP,
-     HBONE), so this example does not validate. Flagged for a content/product review of the
-     "Auto-detect protocol" section before adding a test. -->
 
 ## TLS Listeners
 
@@ -278,18 +255,20 @@ While both a TCP and TLS passthrough listener do not terminate TLS, the latter e
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 8443
-  listeners:
-  - hostname: passthrough.example.com
-    protocol: TLS
-    tcpRoutes: []
-  - hostname: termination.example.com
-    protocol: TLS
-    tcpRoutes: []
-    tls:
-      cert: examples/tls/certs/cert.pem
-      key: examples/tls/certs/key.pem
+gateways:
+  tls:
+    port: 8443
+    listeners:
+    - name: passthrough
+      hostname: passthrough.example.com
+      protocol: TLS
+    - name: termination
+      hostname: termination.example.com
+      protocol: TLS
+      tls:
+        cert: examples/tls/certs/cert.pem
+        key: examples/tls/certs/key.pem
+tcpRoutes: []
 ```
 
 {{< doc-test paths="listeners" >}}
@@ -300,18 +279,20 @@ binds:
 #     connections and backends the page does not exercise.
 cat <<'EOF' > config7.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 8443
-  listeners:
-  - hostname: passthrough.example.com
-    protocol: TLS
-    tcpRoutes: []
-  - hostname: termination.example.com
-    protocol: TLS
-    tcpRoutes: []
-    tls:
-      cert: examples/tls/certs/cert.pem
-      key: examples/tls/certs/key.pem
+gateways:
+  tls:
+    port: 8443
+    listeners:
+    - name: passthrough
+      hostname: passthrough.example.com
+      protocol: TLS
+    - name: termination
+      hostname: termination.example.com
+      protocol: TLS
+      tls:
+        cert: examples/tls/certs/cert.pem
+        key: examples/tls/certs/key.pem
+tcpRoutes: []
 EOF
 agentgateway -f config7.yaml --validate-only
 {{< /doc-test >}}

--- a/content/docs/standalone/main/configuration/overview.md
+++ b/content/docs/standalone/main/configuration/overview.md
@@ -2,7 +2,7 @@
 title: Overview
 weight: 10
 description: Understand agentgateway's top-level configuration sections and how to write, update, and run a configuration file.
-next: /configuration/listeners
+next: /configuration/gateways
 ---
 
 Manage agentgateway through a configuration file. Supported file formats are JSON and YAML.
@@ -12,9 +12,12 @@ Manage agentgateway through a configuration file. Supported file formats are JSO
 Agentgateway configuration has a few top level sections:
 
 * `config` configures top level settings. These options are the only ones that are not dynamically configured.
-* `binds` provides the entry point to routing configuration using the traditional listeners, routes, and backends model. For a simplified configuration, use the `llm` or `mcp` top-level fields instead.
+* `gateways` provides the entry point for traffic, defining the ports and listeners that routes and features attach to. For more information, see [Gateways]({{< link-hextra path="/configuration/gateways/" >}}).
+* `routes` and `tcpRoutes` define how traffic that reaches a gateway is matched and forwarded to backends.
 * `llm` provides a simplified, model-centric configuration for routing requests to LLM providers. For more information, see [LLM configuration modes]({{< link-hextra path="/llm/configuration-modes/" >}}).
-* `mcp` provides a simplified configuration for connecting to MCP servers without requiring the full `binds` routing structure.
+* `mcp` provides a simplified configuration for connecting to MCP servers without requiring individual routes and backends.
+* `ui` exposes the agentgateway UI on a gateway instead of only on the admin interface.
+* `binds` is the deprecated predecessor to `gateways`, which nests listeners and routes under each port. Use `gateways` and `routes` instead. For help converting, see [Migrate from binds]({{< link-hextra path="/configuration/gateways/#migrate-from-binds" >}}).
 * `services` and `workloads` can be used for very advanced cases where backends need to be represented as complex objects rather than simple URLs. However, it is recommended to [use agentgateway on Kubernetes](https://agentgateway.dev/docs/kubernetes/) for these purposes.
 
 
@@ -41,20 +44,21 @@ agentgateway -f config.yaml
 
 ## Configuration overview
 
-Agentgateway's core configuration is made up of {{< gloss "Listener" >}}listeners{{< /gloss >}}, {{< gloss "Route" >}}routes{{< /gloss >}}, and {{< gloss "Backend" >}}backends{{< /gloss >}}.
+Agentgateway's core configuration is made up of gateways, {{< gloss "Listener" >}}listeners{{< /gloss >}}, {{< gloss "Route" >}}routes{{< /gloss >}}, and {{< gloss "Backend" >}}backends{{< /gloss >}}.
 
-* **Listeners** are the main entry point for incoming traffic. For a simple setup, you might have just a single listener. More complex setups might have multiple listeners to serve different ports or domains.
-* **Routes** define how incoming traffic is matched and forwarded to backends.
+* **Gateways** are the main entry point for incoming traffic. Each gateway is a named port. For a simple setup, you might have just a single gateway. More complex setups might have multiple gateways to serve different ports.
+* **Listeners** subdivide a gateway when one port must serve multiple domains with different TLS certificates.
+* **Routes** define how incoming traffic is matched and forwarded to backends. Routes attach to gateways by name.
 * **Backends** are the targets that receive traffic from agentgateway. Backends can be simple URLs or more complex backends, like an MCP server or {{< gloss "Provider" >}}LLM provider{{< /gloss >}}.
 
 A minimal configuration that accepts HTTP traffic on port 3000 and forwards it to a backend running on `localhost:8000` looks like the following example.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8000
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8000
 ```

--- a/content/docs/standalone/main/configuration/policies/_index.md
+++ b/content/docs/standalone/main/configuration/policies/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Policies
-weight: 11
+weight: 40
 description: Apply policies to shape traffic that flows through agentgateway.
 ---
 

--- a/content/docs/standalone/main/configuration/policies/attachment.md
+++ b/content/docs/standalone/main/configuration/policies/attachment.md
@@ -5,7 +5,7 @@ description: Learn how to attach policies to different resources in agentgateway
 test: skip
 ---
 
-You can attach policies at the {{< gloss "Listener" >}}listener{{< /gloss >}}, {{< gloss "Route" >}}route{{< /gloss >}}, or {{< gloss "Backend" >}}backend{{< /gloss >}} level to provide fine-grained control over traffic.
+You can attach policies at the gateway or {{< gloss "Listener" >}}listener{{< /gloss >}}, {{< gloss "Route" >}}route{{< /gloss >}}, or {{< gloss "Backend" >}}backend{{< /gloss >}} level to provide fine-grained control over traffic.
 
 ## Phases
 
@@ -13,7 +13,7 @@ Policies that are attached at multiple levels are applied at all levels.
 
 |Section|Available Policies|Phase|
 |-|-|-|
-|Listener|{{< gloss "JWT (JSON Web Token)" >}}JWT{{< /gloss >}}, External Authorization, {{< gloss "ExtProc (External Processing)" >}}External Processing{{< /gloss >}}, {{< gloss "Transformation" >}}Transformation{{< /gloss >}}, Basic {{< gloss "Authentication (AuthN)" >}}Authentication{{< /gloss >}}, {{< gloss "API Key" >}}API Key{{< /gloss >}} authentication|Runs before route selection|
+|Gateway or listener|{{< gloss "JWT (JSON Web Token)" >}}JWT{{< /gloss >}}, External Authorization, {{< gloss "ExtProc (External Processing)" >}}External Processing{{< /gloss >}}, {{< gloss "Transformation" >}}Transformation{{< /gloss >}}, Basic {{< gloss "Authentication (AuthN)" >}}Authentication{{< /gloss >}}, {{< gloss "API Key" >}}API Key{{< /gloss >}} authentication|Runs before route selection|
 |Route|All Policies|Runs after route selection, before backend selection|
 |Backend|Backend TLS, Backend Authentication, Backend HTTP, Backend TCP, AI/LLM, MCP Authorization, MCP Authentication, External Authorization, Header modification|Runs after backend selection|
 
@@ -23,34 +23,33 @@ Review the following example configuration that uses one of each policy type.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  # Listener level policy
-  # Enforces that incoming requests have a valid {{< gloss "API Key" >}}API key{{< /gloss >}}
-  - policies:
-      apiKey:
-        mode: strict
-        keys:
-        - key: sk-testkey-1
-          metadata:
-            user: test
-            role: admin
-    routes:
-    # Route level policy
-    # Adds a header (based on a {{< gloss "CEL (Common Expression Language)" >}}CEL{{< /gloss >}} expression) with the authenticated user (based on the API key)
-    - policies:
-        transformations:
-          request:
-            set:
-              x-authenticated-user: apiKey.user
-      backends:
-      - host: localhost:8080
-        # Backend level policy
-        # Adds an Authorization header to outgoing requests
-        policies:
-          backendAuth:
-            key: my-authorization-header
+gateways:
+  default:
+    port: 3000
+    # Gateway level policy
+    # Enforces that incoming requests have a valid {{< gloss "API Key" >}}API key{{< /gloss >}}
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-testkey-1
+        metadata:
+          user: test
+          role: admin
+routes:
+# Route level policy
+# Adds a header (based on a {{< gloss "CEL (Common Expression Language)" >}}CEL{{< /gloss >}} expression) with the authenticated user (based on the API key)
+- policies:
+    transformations:
+      request:
+        set:
+          x-authenticated-user: apiKey.user
+  backends:
+  - host: localhost:8080
+    # Backend level policy
+    # Adds an Authorization header to outgoing requests
+    policies:
+      backendAuth:
+        key: my-authorization-header
 ```
 
 ## More policy configuration guides

--- a/content/docs/standalone/main/configuration/resiliency/_index.md
+++ b/content/docs/standalone/main/configuration/resiliency/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Resiliency
-weight: 50
+weight: 60
 description: Configure retries, timeouts, rate limits, and mirroring for fault tolerance.
 prev: /configuration/traffic-management
 next: /configuration/security

--- a/content/docs/standalone/main/configuration/resiliency/fault-injection.md
+++ b/content/docs/standalone/main/configuration/resiliency/fault-injection.md
@@ -53,15 +53,15 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        delay:
-          duration: 2s
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    delay:
+      duration: 2s
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -80,15 +80,15 @@ The following example delays approximately 10% of requests by 500ms.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        delay:
-          duration: "random() < 0.1 ? 500 : 0"
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    delay:
+      duration: "random() < 0.1 ? 500 : 0"
+  backends:
+  - host: localhost:8080
 ```
 
 {{< doc-test paths="fault-injection" >}}
@@ -101,15 +101,15 @@ binds:
 #     omits.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        delay:
-          duration: 2s
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    delay:
+      duration: 2s
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -130,15 +130,15 @@ agentgateway -f config-mcp.yaml --validate-only
 
 cat <<'EOF' > config-cel.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        delay:
-          duration: "random() < 0.1 ? 500 : 0"
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    delay:
+      duration: "random() < 0.1 ? 500 : 0"
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config-cel.yaml --validate-only
 {{< /doc-test >}}

--- a/content/docs/standalone/main/configuration/resiliency/mirroring.md
+++ b/content/docs/standalone/main/configuration/resiliency/mirroring.md
@@ -41,18 +41,18 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        requestMirror:
-          backend:
-            host: localhost:8080
-          # Mirror 50% of requests
-          percentage: 0.5
-      backends:
-      - host: localhost:8000
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    requestMirror:
+      backend:
+        host: localhost:8080
+      # Mirror 50% of requests
+      percentage: 0.5
+  backends:
+  - host: localhost:8000
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -60,24 +60,24 @@ binds:
 {{< doc-test paths="mirroring" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The requestMirror policy is accepted by agentgateway in both the
-#     routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That requests are actually mirrored at runtime — requires live primary
 #     and mirror backends the page omits to send to and inspect.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        requestMirror:
-          backend:
-            host: localhost:8080
-          # Mirror 50% of requests
-          percentage: 0.5
-      backends:
-      - host: localhost:8000
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    requestMirror:
+      backend:
+        host: localhost:8080
+      # Mirror 50% of requests
+      percentage: 0.5
+  backends:
+  - host: localhost:8000
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/resiliency/rate-limits.md
+++ b/content/docs/standalone/main/configuration/resiliency/rate-limits.md
@@ -77,18 +77,18 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        localRateLimit:
-        - maxTokens: 10
-          tokensPerFill: 1
-          fillInterval: 60s
-          type: requests
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    localRateLimit:
+    - maxTokens: 10
+      tokensPerFill: 1
+      fillInterval: 60s
+      type: requests
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< tab name="traffic-ratelimiting-local example" >}}
@@ -101,25 +101,25 @@ For a runnable version of the routing-based configuration, see the [`traffic-rat
 {{< doc-test paths="rate-limits" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The request-based localRateLimit policy is accepted by agentgateway in the
-#     routing-based (binds), simplified LLM (llm.policies), and simplified MCP
+#     routing-based (gateways), simplified LLM (llm.policies), and simplified MCP
 #     (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That requests are actually limited at runtime — requires driving traffic
 #     past the configured bucket, which the page does not exercise.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        localRateLimit:
-        - maxTokens: 10
-          tokensPerFill: 1
-          fillInterval: 60s
-          type: requests
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    localRateLimit:
+    - maxTokens: 10
+      tokensPerFill: 1
+      fillInterval: 60s
+      type: requests
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -248,24 +248,24 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        localRateLimit:
-        - maxTokens: 5000
-          # Every hour, refill 5000 tokens
-          tokensPerFill: 5000
-          fillInterval: 1h
-          type: tokens
-        - maxTokens: 60
-          # Every second, refill 1 token
-          tokensPerFill: 1
-          fillInterval: 1s
-          type: requests
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    localRateLimit:
+    - maxTokens: 5000
+      # Every hour, refill 5000 tokens
+      tokensPerFill: 5000
+      fillInterval: 1h
+      type: tokens
+    - maxTokens: 60
+      # Every second, refill 1 token
+      tokensPerFill: 1
+      fillInterval: 1s
+      type: requests
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -273,7 +273,7 @@ binds:
 {{< doc-test paths="rate-limits" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The Local example config (5000 tokens/hour and 60 requests/second) is
-#     accepted by agentgateway in the routing-based (binds), simplified LLM
+#     accepted by agentgateway in the routing-based (gateways), simplified LLM
 #     (llm.policies), and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That the token-bucket limits actually refill and throttle at runtime —
@@ -282,24 +282,24 @@ binds:
 #     reference snippets, not standalone configs, so they are not tested here.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        localRateLimit:
-        - maxTokens: 5000
-          # Every hour, refill 5000 tokens
-          tokensPerFill: 5000
-          fillInterval: 1h
-          type: tokens
-        - maxTokens: 60
-          # Every second, refill 1 token
-          tokensPerFill: 1
-          fillInterval: 1s
-          type: requests
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    localRateLimit:
+    - maxTokens: 5000
+      # Every hour, refill 5000 tokens
+      tokensPerFill: 5000
+      fillInterval: 1h
+      type: tokens
+    - maxTokens: 60
+      # Every second, refill 1 token
+      tokensPerFill: 1
+      fillInterval: 1s
+      type: requests
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config2.yaml --validate-only
 
@@ -483,28 +483,28 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        remoteRateLimit:
-          # The address to access the rate limit server
-          host: localhost:8081
-          # Arbitrary 'domain' to match limits on the rate limit server
-          domain: example.com
-          descriptors:
-          # Rate limit requests based on a header, whether the user is authenticated, and a static value (used to match a specific rate limit rule on the rate limit server)
-          - entries:
-            - key: some-static-value
-              value: '"something"'
-            - key: organization
-              value: 'request.headers["x-organization"]'
-            - key: authenticated
-              value: 'has(jwt.sub)'
-            type: tokens # or 'requests'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    remoteRateLimit:
+      # The address to access the rate limit server
+      host: localhost:8081
+      # Arbitrary 'domain' to match limits on the rate limit server
+      domain: example.com
+      descriptors:
+      # Rate limit requests based on a header, whether the user is authenticated, and a static value (used to match a specific rate limit rule on the rate limit server)
+      - entries:
+        - key: some-static-value
+          value: '"something"'
+        - key: organization
+          value: 'request.headers["x-organization"]'
+        - key: authenticated
+          value: 'has(jwt.sub)'
+        type: tokens # or 'requests'
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -512,7 +512,7 @@ binds:
 {{< doc-test paths="rate-limits" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The Remote example config (remoteRateLimit with descriptors) is accepted
-#     by agentgateway in the routing-based (binds), simplified LLM
+#     by agentgateway in the routing-based (gateways), simplified LLM
 #     (llm.policies), and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That limits are actually enforced at runtime — requires an external Envoy
@@ -521,28 +521,28 @@ binds:
 #     field-reference fragments, not standalone configs, so they are not tested.
 cat <<'EOF' > config3.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        remoteRateLimit:
-          # The address to access the rate limit server
-          host: localhost:8081
-          # Arbitrary 'domain' to match limits on the rate limit server
-          domain: example.com
-          descriptors:
-          # Rate limit requests based on a header, whether the user is authenticated, and a static value (used to match a specific rate limit rule on the rate limit server)
-          - entries:
-            - key: some-static-value
-              value: '"something"'
-            - key: organization
-              value: 'request.headers["x-organization"]'
-            - key: authenticated
-              value: 'has(jwt.sub)'
-            type: tokens # or 'requests'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    remoteRateLimit:
+      # The address to access the rate limit server
+      host: localhost:8081
+      # Arbitrary 'domain' to match limits on the rate limit server
+      domain: example.com
+      descriptors:
+      # Rate limit requests based on a header, whether the user is authenticated, and a static value (used to match a specific rate limit rule on the rate limit server)
+      - entries:
+        - key: some-static-value
+          value: '"something"'
+        - key: organization
+          value: 'request.headers["x-organization"]'
+        - key: authenticated
+          value: 'has(jwt.sub)'
+        type: tokens # or 'requests'
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config3.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/resiliency/retries.md
+++ b/content/docs/standalone/main/configuration/resiliency/retries.md
@@ -45,22 +45,22 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        retry:
-          # total number of attempts allowed.
-          # Note: 1 attempt implies no retries; the initial attempt is included in the count.
-          attempts: 3
-          # Optional; if set, a delay between each additional attempt
-          backoff: 500ms
-          # A list of HTTP response codes to consider retry-able.
-          # In addition, retries are always permitted if the request to a backend was never started.
-          codes: [429, 500, 503]
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    retry:
+      # total number of attempts allowed.
+      # Note: 1 attempt implies no retries; the initial attempt is included in the count.
+      attempts: 3
+      # Optional; if set, a delay between each additional attempt
+      backoff: 500ms
+      # A list of HTTP response codes to consider retry-able.
+      # In addition, retries are always permitted if the request to a backend was never started.
+      codes: [429, 500, 503]
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -68,28 +68,28 @@ binds:
 {{< doc-test paths="retries" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The retry policy is accepted by agentgateway in both the routing-based
-#     (binds) and simplified MCP (mcp.policies) forms.
+#     (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That failed requests are actually retried at runtime — requires a backend
 #     that returns the retry-able codes the page omits to drive the behavior.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        retry:
-          # total number of attempts allowed.
-          # Note: 1 attempt implies no retries; the initial attempt is included in the count.
-          attempts: 3
-          # Optional; if set, a delay between each additional attempt
-          backoff: 500ms
-          # A list of HTTP response codes to consider retry-able.
-          # In addition, retries are always permitted if the request to a backend was never started.
-          codes: [429, 500, 503]
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    retry:
+      # total number of attempts allowed.
+      # Note: 1 attempt implies no retries; the initial attempt is included in the count.
+      attempts: 3
+      # Optional; if set, a delay between each additional attempt
+      backoff: 500ms
+      # A list of HTTP response codes to consider retry-able.
+      # In addition, retries are always permitted if the request to a backend was never started.
+      codes: [429, 500, 503]
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/resiliency/timeouts.md
+++ b/content/docs/standalone/main/configuration/resiliency/timeouts.md
@@ -46,15 +46,15 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        timeout:
-          requestTimeout: 1s
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    timeout:
+      requestTimeout: 1s
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -62,21 +62,21 @@ binds:
 {{< doc-test paths="timeouts" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The route-level timeout policy is accepted by agentgateway in both the
-#     routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That requests actually time out at runtime — requires a slow backend the
 #     page omits to exceed the configured deadline.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        timeout:
-          requestTimeout: 1s
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    timeout:
+      requestTimeout: 1s
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -107,19 +107,19 @@ In addition to route level timeouts, you can configure per-backend timeouts with
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          http:
-            requestTimeout: 1s
-          tcp:
-            connectTimeout: 10s
-            # Required when setting tcp connection options; {} keeps keepalive defaults
-            keepalives: {}
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      http:
+        requestTimeout: 1s
+      tcp:
+        connectTimeout: 10s
+        # Required when setting tcp connection options; {} keeps keepalive defaults
+        keepalives: {}
 ```
 
 {{< doc-test paths="timeouts" >}}
@@ -130,19 +130,19 @@ binds:
 #     requires a slow/unreachable backend the page omits to trigger them.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          http:
-            requestTimeout: 1s
-          tcp:
-            connectTimeout: 10s
-            # Required when setting tcp connection options; {} keeps keepalive defaults
-            keepalives: {}
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      http:
+        requestTimeout: 1s
+      tcp:
+        connectTimeout: 10s
+        # Required when setting tcp connection options; {} keeps keepalive defaults
+        keepalives: {}
 EOF
 agentgateway -f config2.yaml --validate-only
 {{< /doc-test >}}

--- a/content/docs/standalone/main/configuration/routes.md
+++ b/content/docs/standalone/main/configuration/routes.md
@@ -1,11 +1,11 @@
 ---
 title: Routes
 weight: 14
-description: Match HTTP and TCP traffic on a listener and forward it to backends.
+description: Match HTTP and TCP traffic on a gateway and forward it to backends.
 next: /configuration/traffic-management
 ---
 
-{{< gloss "Route" >}}Routes{{< /gloss >}} are the entry points for traffic to your agentgateway. They are configured on listeners and are used to route traffic to {{< gloss "Backend" >}}backends{{< /gloss >}}.
+{{< gloss "Route" >}}Routes{{< /gloss >}} are the entry points for traffic to your agentgateway. They attach to [gateways]({{< link-hextra path="/configuration/gateways/" >}}) and are used to route traffic to {{< gloss "Backend" >}}backends{{< /gloss >}}.
 
 ## Types of routes
 
@@ -13,35 +13,34 @@ You can configure two types of routes: HTTP routes (`routes`) and TCP routes (`t
 
 ### HTTP routes
 
-[HTTP or HTTPS listeners](../listeners/) use `routes` to configure HTTP routes. HTTP routes support all HTTP features such as path, header, method, or query {{< gloss "Matching" >}}matching{{< /gloss >}}, and HTTP-specific filters and {{< gloss "Policy" >}}policies{{< /gloss >}}.
+[HTTP or HTTPS gateways](../listeners/) use `routes` to configure HTTP routes. HTTP routes support all HTTP features such as path, header, method, or query {{< gloss "Matching" >}}matching{{< /gloss >}}, and HTTP-specific filters and {{< gloss "Policy" >}}policies{{< /gloss >}}.
 
 Example configuration:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 8080
-  listeners:
-  - name: http-proxy
+gateways:
+  http-proxy:
+    port: 8080
     protocol: HTTP
-    routes:
-    - name: http-backend
-      hostnames:
-      - "example.com"
-      matches:
-      - path:
-          type: PathPrefix
-          value: /
-      backends:
-      - host: http.example.com:8080
-        weight: 1
+routes:
+- name: http-backend
+  gateways: [http-proxy]
+  hostnames:
+  - "example.com"
+  matches:
+  - path:
+      pathPrefix: /
+  backends:
+  - host: http.example.com:8080
+    weight: 1
 ```
 
 HTTP routes support various matching options for incoming requests. For more information, see the [Request matching]({{< link-hextra path="/configuration/traffic-management/matching/" >}}) guide.
 
 ### TCP routes
 
-[TCP listeners](../listeners) use `tcpRoutes` instead of `routes`. TCP routes have a simpler structure than HTTP routes.
+[TCP gateways](../listeners) use `tcpRoutes` instead of `routes`. TCP routes have a simpler structure than HTTP routes.
 
 Keep in mind that TCP routes do not support HTTP features such as path, header, method, or query matching, and HTTP-specific filters and policies.
 
@@ -49,26 +48,27 @@ Example configuration:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 5432
-  listeners:
-  - name: postgres-proxy
+gateways:
+  postgres-proxy:
+    port: 5432
     protocol: TCP
-    tcpRoutes:
-    - name: postgres-backend
-      backends:
-      - host: postgres.example.com:5432
-        weight: 1
+tcpRoutes:
+- name: postgres-backend
+  gateways: [postgres-proxy]
+  backends:
+  - host: postgres.example.com:5432
+    weight: 1
 ```
 
 For more information, see [TCP route matching]({{< link-hextra path="/configuration/traffic-management/matching#tcp-routes" >}}).
 
 ## Route configuration
 
-Routes are configured within the `routes` or `tcpRoutes` section of a listener. The following fields are available for route configuration:
+Routes are configured in the top-level `routes` or `tcpRoutes` section. The following fields are available for route configuration:
 
 | Field | Description |
 |-------|-------------|
+| `gateways` | The gateways that the route attaches to, in the form `<gateway-name>` or `<gateway-name>/<listener-name>`. When omitted, the route attaches to the gateway named `default`. |
 | `name` | An optional name for the route. |
 | `hostnames` | A list of hostnames that the route serves traffic on. |
 | `matches` | Defines the matching rules for the route, including path, headers, methods, and query parameters. For more options, see the [Request matching]({{< link-hextra path="/configuration/traffic-management/matching/" >}}) guide. |
@@ -92,27 +92,27 @@ The following example shows a route with CORS policy configuration:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        cors:
-          allowOrigins:
-          - "*"
-          allowHeaders:
-          - mcp-protocol-version
-          - content-type
-          - cache-control
-          exposeHeaders:
-          - "Mcp-Session-Id"
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    cors:
+      allowOrigins:
+      - "*"
+      allowHeaders:
+      - mcp-protocol-version
+      - content-type
+      - cache-control
+      exposeHeaders:
+      - "Mcp-Session-Id"
+  backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
 ```
 
 ## Next steps

--- a/content/docs/standalone/main/configuration/routes.md
+++ b/content/docs/standalone/main/configuration/routes.md
@@ -1,6 +1,6 @@
 ---
 title: Routes
-weight: 14
+weight: 30
 description: Match HTTP and TCP traffic on a gateway and forward it to backends.
 next: /configuration/traffic-management
 ---

--- a/content/docs/standalone/main/configuration/security/_index.md
+++ b/content/docs/standalone/main/configuration/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-weight: 60
+weight: 70
 description: Compare the authentication, authorization, TLS, and rate limiting policies available to protect your gateway.
 prev: /configuration/resiliency
 next: /reference

--- a/content/docs/standalone/main/configuration/security/apikey-authn.md
+++ b/content/docs/standalone/main/configuration/security/apikey-authn.md
@@ -73,20 +73,19 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      apiKey:
-        mode: strict
-        keys:
-        - key: sk-testkey-1
-          metadata:
-            user: test
-            role: admin
-    routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-testkey-1
+        metadata:
+          user: test
+          role: admin
+routes:
+- backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -94,27 +93,26 @@ binds:
 {{< doc-test paths="apikey-authn" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The apiKey authentication policy is accepted by agentgateway in all three
-#     configuration forms: routing-based (binds), simplified LLM (llm.policies),
+#     configuration forms: routing-based (gateways), simplified LLM (llm.policies),
 #     and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That a request with the given key is actually authenticated at runtime —
 #     requires a backend the page omits to forward to.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      apiKey:
-        mode: strict
-        keys:
-        - key: sk-testkey-1
-          metadata:
-            user: test
-            role: admin
-    routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-testkey-1
+        metadata:
+          user: test
+          role: admin
+routes:
+- backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -211,25 +209,24 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      apiKey:
-        mode: strict
-        keys:
-        - key: sk-testkey-1
-          metadata:
-            user: test
-            role: admin
-    routes:
-    - policies:
-        transformations:
-          request:
-            set:
-              x-authenticated-user: apiKey.user
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-testkey-1
+        metadata:
+          user: test
+          role: admin
+routes:
+- policies:
+    transformations:
+      request:
+        set:
+          x-authenticated-user: apiKey.user
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -238,32 +235,31 @@ binds:
 # WHAT THIS TEST VALIDATES:
 #   * The apiKey config combined with a transformation that sets a header from
 #     API key metadata is accepted by agentgateway in all three configuration
-#     forms: routing-based (binds), simplified LLM (llm.policies), and simplified
+#     forms: routing-based (gateways), simplified LLM (llm.policies), and simplified
 #     MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That the x-authenticated-user header is actually set at runtime —
 #     requires a backend the page omits to forward to and inspect.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      apiKey:
-        mode: strict
-        keys:
-        - key: sk-testkey-1
-          metadata:
-            user: test
-            role: admin
-    routes:
-    - policies:
-        transformations:
-          request:
-            set:
-              x-authenticated-user: apiKey.user
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-testkey-1
+        metadata:
+          user: test
+          role: admin
+routes:
+- policies:
+    transformations:
+      request:
+        set:
+          x-authenticated-user: apiKey.user
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config2.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/backend-authn/_index.md
+++ b/content/docs/standalone/main/configuration/security/backend-authn/_index.md
@@ -45,16 +45,16 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          backendAuth:
-            key:
-              value: $MY_API_KEY
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      backendAuth:
+        key:
+          value: $MY_API_KEY
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -62,24 +62,24 @@ binds:
 {{< doc-test paths="backend-authn" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The static-key backendAuth example config is accepted by agentgateway in
-#     both the routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     both the routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * The other backendAuth snippets on this page (file path, location,
 #     passthrough, gcp, aws, crossAppAccess) are field-reference fragments
-#     with no `binds:`, so they are not standalone configs and are not
+#     with no `gateways:`, so they are not standalone configs and are not
 #     tested here.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          backendAuth:
-            key:
-              value: $MY_API_KEY
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      backendAuth:
+        key:
+          value: $MY_API_KEY
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/backend-tls.md
+++ b/content/docs/standalone/main/configuration/security/backend-tls.md
@@ -55,25 +55,25 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8443
-        policies:
-          backendTLS:
-            # A file containing the root certificate to verify.
-            # If unset, the system trust bundle will be used.
-            root: ./certs/root-cert.pem
-            # For mutual TLS, the client certificate to use
-            cert: ./certs/cert.pem
-            # For mutual TLS, the client certificate key to use.
-            key: ./certs/key.pem
-            # If set, hostname verification is disabled
-            # insecureHost: true
-            # If set, all TLS verification is disabled
-            # insecure: true
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8443
+    policies:
+      backendTLS:
+        # A file containing the root certificate to verify.
+        # If unset, the system trust bundle will be used.
+        root: ./certs/root-cert.pem
+        # For mutual TLS, the client certificate to use
+        cert: ./certs/cert.pem
+        # For mutual TLS, the client certificate key to use.
+        key: ./certs/key.pem
+        # If set, hostname verification is disabled
+        # insecureHost: true
+        # If set, all TLS verification is disabled
+        # insecure: true
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -81,31 +81,31 @@ binds:
 {{< doc-test paths="backend-tls" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The backendTLS example config is accepted by agentgateway in both the
-#     routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That the TLS handshake to the backend succeeds at runtime — requires an
 #     HTTPS backend on localhost:8443 the page omits.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8443
-        policies:
-          backendTLS:
-            # A file containing the root certificate to verify.
-            # If unset, the system trust bundle will be used.
-            root: ./certs/root-cert.pem
-            # For mutual TLS, the client certificate to use
-            cert: ./certs/cert.pem
-            # For mutual TLS, the client certificate key to use.
-            key: ./certs/key.pem
-            # If set, hostname verification is disabled
-            # insecureHost: true
-            # If set, all TLS verification is disabled
-            # insecure: true
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8443
+    policies:
+      backendTLS:
+        # A file containing the root certificate to verify.
+        # If unset, the system trust bundle will be used.
+        root: ./certs/root-cert.pem
+        # For mutual TLS, the client certificate to use
+        cert: ./certs/cert.pem
+        # For mutual TLS, the client certificate key to use.
+        key: ./certs/key.pem
+        # If set, hostname verification is disabled
+        # insecureHost: true
+        # If set, all TLS verification is disabled
+        # insecure: true
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/basic-authn.md
+++ b/content/docs/standalone/main/configuration/security/basic-authn.md
@@ -79,23 +79,22 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      basicAuth:
-        mode: strict
-        # Generated with `htpasswd -nb -B user1 agentgateway`
-        # You can also use:
-        # htpasswd:
-        #   file: /path/to/htpasswd
-        # With inline configuration, $ must be escaped to $$.
-        htpasswd: |
-          user1:$$2y$$05$$LMZ.8WGNqvagmtJz2Gw6VuiE6khXc2zc0FDTHrfWJyLT66HM8BMAa
-        realm: example.com
-    routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    basicAuth:
+      mode: strict
+      # Generated with `htpasswd -nb -B user1 agentgateway`
+      # You can also use:
+      # htpasswd:
+      #   file: /path/to/htpasswd
+      # With inline configuration, $ must be escaped to $$.
+      htpasswd: |
+        user1:$$2y$$05$$LMZ.8WGNqvagmtJz2Gw6VuiE6khXc2zc0FDTHrfWJyLT66HM8BMAa
+      realm: example.com
+routes:
+- backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -103,30 +102,29 @@ binds:
 {{< doc-test paths="basic-authn" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The basicAuth authentication policy is accepted by agentgateway in all
-#     three configuration forms: routing-based (binds), simplified LLM
+#     three configuration forms: routing-based (gateways), simplified LLM
 #     (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That credentials are actually enforced at runtime — requires a backend
 #     the page omits to forward to.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      basicAuth:
-        mode: strict
-        # Generated with `htpasswd -nb -B user1 agentgateway`
-        # You can also use:
-        # htpasswd:
-        #   file: /path/to/htpasswd
-        # With inline configuration, $ must be escaped to $$.
-        htpasswd: |
-          user1:$$2y$$05$$LMZ.8WGNqvagmtJz2Gw6VuiE6khXc2zc0FDTHrfWJyLT66HM8BMAa
-        realm: example.com
-    routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    basicAuth:
+      mode: strict
+      # Generated with `htpasswd -nb -B user1 agentgateway`
+      # You can also use:
+      # htpasswd:
+      #   file: /path/to/htpasswd
+      # With inline configuration, $ must be escaped to $$.
+      htpasswd: |
+        user1:$$2y$$05$$LMZ.8WGNqvagmtJz2Gw6VuiE6khXc2zc0FDTHrfWJyLT66HM8BMAa
+      realm: example.com
+routes:
+- backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/cors.md
+++ b/content/docs/standalone/main/configuration/security/cors.md
@@ -112,27 +112,27 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: api.example.com:443
-      policies:
-        cors:
-          allowOrigins:
-          - https://app.example.com
-          allowMethods:
-          - GET
-          - POST
-          - OPTIONS
-          allowHeaders:
-          - authorization
-          - content-type
-          exposeHeaders:
-          - x-request-id
-          allowCredentials: true
-          maxAge: 100s
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: api.example.com:443
+  policies:
+    cors:
+      allowOrigins:
+      - https://app.example.com
+      allowMethods:
+      - GET
+      - POST
+      - OPTIONS
+      allowHeaders:
+      - authorization
+      - content-type
+      exposeHeaders:
+      - x-request-id
+      allowCredentials: true
+      maxAge: 100s
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/content/docs/standalone/main/configuration/security/csrf.md
+++ b/content/docs/standalone/main/configuration/security/csrf.md
@@ -99,17 +99,17 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        csrf:
-          additionalOrigins:
-          - "https://www.example.com"
-          - "https://trusted.domain.com"
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    csrf:
+      additionalOrigins:
+      - "https://www.example.com"
+      - "https://trusted.domain.com"
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -117,25 +117,25 @@ binds:
 {{< doc-test paths="csrf" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The csrf policy with an additionalOrigins list is accepted by agentgateway
-#     in both the routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     in both the routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That cross-site requests are actually blocked/allowed at runtime — requires
 #     a backend the page omits to forward to.
 #   * The standalone `additionalOrigins: []` snippet later on the page is a
-#     fragment (no binds:), so it is intentionally not tested.
+#     fragment (no `gateways:`), so it is intentionally not tested.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        csrf:
-          additionalOrigins:
-          - "https://www.example.com"
-          - "https://trusted.domain.com"
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    csrf:
+      additionalOrigins:
+      - "https://www.example.com"
+      - "https://trusted.domain.com"
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/external-authz.md
+++ b/content/docs/standalone/main/configuration/security/external-authz.md
@@ -75,21 +75,21 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        extAuthz:
-          host: localhost:9000
-          protocol:
-            grpc:
-              # Optional: metadata to send to the external authorization service
-              # The value is a CEL expression
-              metadata:
-                dev.agentgateway.jwt: '{"claims": jwt}'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    extAuthz:
+      host: localhost:9000
+      protocol:
+        grpc:
+          # Optional: metadata to send to the external authorization service
+          # The value is a CEL expression
+          metadata:
+            dev.agentgateway.jwt: '{"claims": jwt}'
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -97,30 +97,30 @@ binds:
 {{< doc-test paths="external-authz" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The gRPC extAuthz policy example config is accepted by agentgateway in all
-#     three configuration forms: routing-based (binds), simplified LLM
+#     three configuration forms: routing-based (gateways), simplified LLM
 #     (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That authorization decisions are actually enforced at runtime — requires a
 #     running external authorization service the page omits.
 #   * The bare `extAuthz:` snippets later on the page are focused fragments
-#     (no binds:), so they are not tested.
+#     (no `gateways:`), so they are not tested.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        extAuthz:
-          host: localhost:9000
-          protocol:
-            grpc:
-              # Optional: metadata to send to the external authorization service
-              # The value is a CEL expression
-              metadata:
-                dev.agentgateway.jwt: '{"claims": jwt}'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    extAuthz:
+      host: localhost:9000
+      protocol:
+        grpc:
+          # Optional: metadata to send to the external authorization service
+          # The value is a CEL expression
+          metadata:
+            dev.agentgateway.jwt: '{"claims": jwt}'
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -275,17 +275,17 @@ extAuthz:
 You can also attach an `extAuthz` policy directly to a backend. Backend-level external authorization runs after agentgateway selects the backend, so the policy applies even when a route load-balances or fails over across multiple backends. Attach at the backend level when the authorization service shapes the outgoing request, for example by inserting a token, rather than only deciding whether the incoming request is allowed.
 
 ```yaml
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          extAuthz:
-            host: localhost:9000
-            protocol:
-              grpc: {}
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      extAuthz:
+        host: localhost:9000
+        protocol:
+          grpc: {}
 ```
 
 {{< doc-test paths="external-authz" >}}
@@ -295,17 +295,17 @@ binds:
 #   * That backend-level authorization is actually enforced at runtime —
 #     requires a running external authorization service the page omits.
 cat <<'EOF' > config2.yaml
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          extAuthz:
-            host: localhost:9000
-            protocol:
-              grpc: {}
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      extAuthz:
+        host: localhost:9000
+        protocol:
+          grpc: {}
 EOF
 agentgateway -f config2.yaml --validate-only
 {{< /doc-test >}}

--- a/content/docs/standalone/main/configuration/security/http-authz.md
+++ b/content/docs/standalone/main/configuration/security/http-authz.md
@@ -81,20 +81,20 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        authorization:
-          rules:
-          - allow: 'request.path == "/authz/public"'
-          - deny: 'request.path == "/authz/deny"'
-          - require: 'jwt.aud == "my-service"'
-          # legacy format; same as `allow: ...`
-          - 'request.headers["x-allow"] == "true"'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    authorization:
+      rules:
+      - allow: 'request.path == "/authz/public"'
+      - deny: 'request.path == "/authz/deny"'
+      - require: 'jwt.aud == "my-service"'
+      # legacy format; same as `allow: ...`
+      - 'request.headers["x-allow"] == "true"'
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -103,7 +103,7 @@ binds:
 # WHAT THIS TEST VALIDATES:
 #   * The authorization policy with allow/deny/require and legacy rules is
 #     accepted by agentgateway in all three configuration forms: routing-based
-#     (binds), simplified LLM (llm.policies), and simplified MCP (mcp.policies).
+#     (gateways), simplified LLM (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That requests are actually allowed/denied at runtime — requires a backend
 #     and traffic the page omits.
@@ -111,20 +111,20 @@ binds:
 #     focused fragments, so they are not tested.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        authorization:
-          rules:
-          - allow: 'request.path == "/authz/public"'
-          - deny: 'request.path == "/authz/deny"'
-          - require: 'jwt.aud == "my-service"'
-          # legacy format; same as `allow: ...`
-          - 'request.headers["x-allow"] == "true"'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    authorization:
+      rules:
+      - allow: 'request.path == "/authz/public"'
+      - deny: 'request.path == "/authz/deny"'
+      - require: 'jwt.aud == "my-service"'
+      # legacy format; same as `allow: ...`
+      - 'request.headers["x-allow"] == "true"'
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/jwt-authn.md
+++ b/content/docs/standalone/main/configuration/security/jwt-authn.md
@@ -82,20 +82,19 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      jwtAuth:
-        mode: strict
-        issuer: agentgateway.dev
-        audiences: [test.agentgateway.dev]
-        jwks:
-          # Relative to the folder the binary runs from, not the config file
-          file: ./manifests/jwt/pub-key
-    routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    jwtAuth:
+      mode: strict
+      issuer: agentgateway.dev
+      audiences: [test.agentgateway.dev]
+      jwks:
+        # Relative to the folder the binary runs from, not the config file
+        file: ./manifests/jwt/pub-key
+routes:
+- backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -103,27 +102,26 @@ binds:
 {{< doc-test paths="jwt-authn" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The jwtAuth policy is accepted by agentgateway in all three configuration
-#     forms: routing-based (binds), simplified LLM (llm.policies), and
+#     forms: routing-based (gateways), simplified LLM (llm.policies), and
 #     simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That a token is actually verified at runtime — requires minting a signed
 #     JWT and a backend the page omits.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      jwtAuth:
-        mode: strict
-        issuer: agentgateway.dev
-        audiences: [test.agentgateway.dev]
-        jwks:
-          # Relative to the folder the binary runs from, not the config file
-          file: ./manifests/jwt/pub-key
-    routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    jwtAuth:
+      mode: strict
+      issuer: agentgateway.dev
+      audiences: [test.agentgateway.dev]
+      jwks:
+        # Relative to the folder the binary runs from, not the config file
+        file: ./manifests/jwt/pub-key
+routes:
+- backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -215,23 +213,22 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      jwtAuth:
-        mode: strict
-        issuer: agentgateway.dev
-        audiences: [test.agentgateway.dev]
-        jwks:
-          file: ./manifests/jwt/pub-key
-    routes:
-    - policies:
-        authorization:
-          rules:
-          - allow: 'request.path == "/admin" && jwt.groups.contains("admins")'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    jwtAuth:
+      mode: strict
+      issuer: agentgateway.dev
+      audiences: [test.agentgateway.dev]
+      jwks:
+        file: ./manifests/jwt/pub-key
+routes:
+- policies:
+    authorization:
+      rules:
+      - allow: 'request.path == "/admin" && jwt.groups.contains("admins")'
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -239,30 +236,29 @@ binds:
 {{< doc-test paths="jwt-authn" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The jwtAuth + authorization example config is accepted by agentgateway in
-#     all three configuration forms: routing-based (binds), simplified LLM
+#     all three configuration forms: routing-based (gateways), simplified LLM
 #     (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That the authorization rule actually allows/denies at runtime — requires
 #     minting a signed JWT with the `admins` group and a backend the page omits.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      jwtAuth:
-        mode: strict
-        issuer: agentgateway.dev
-        audiences: [test.agentgateway.dev]
-        jwks:
-          file: ./manifests/jwt/pub-key
-    routes:
-    - policies:
-        authorization:
-          rules:
-          - allow: 'request.path == "/admin" && jwt.groups.contains("admins")'
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+    jwtAuth:
+      mode: strict
+      issuer: agentgateway.dev
+      audiences: [test.agentgateway.dev]
+      jwks:
+        file: ./manifests/jwt/pub-key
+routes:
+- policies:
+    authorization:
+      rules:
+      - allow: 'request.path == "/admin" && jwt.groups.contains("admins")'
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config2.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/security/mcp-authn.md
+++ b/content/docs/standalone/main/configuration/security/mcp-authn.md
@@ -83,44 +83,44 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      - path:
-          exact: /.well-known/oauth-authorization-server/mcp
-      - path:
-          exact: /.well-known/oauth-authorization-server/mcp/client-registration
-      policies:
-        mcpAuthentication:
-          issuer: http://localhost:7080/realms/mcp
-          audiences: ["http://localhost:3000/mcp"]
-          jwks:
-            url: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
-          provider:
-            keycloak: {}
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - read:all
-            bearerMethodsSupported:
-            - header
-            - body
-            - query
-            resourceDocumentation: http://localhost:3000/stdio/docs
-            resourcePolicyUri: http://localhost:3000/stdio/policies
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  - path:
+      exact: /.well-known/oauth-authorization-server/mcp
+  - path:
+      exact: /.well-known/oauth-authorization-server/mcp/client-registration
+  policies:
+    mcpAuthentication:
+      issuer: http://localhost:7080/realms/mcp
+      audiences: ["http://localhost:3000/mcp"]
+      jwks:
+        url: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
+      provider:
+        keycloak: {}
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - read:all
+        bearerMethodsSupported:
+        - header
+        - body
+        - query
+        resourceDocumentation: http://localhost:3000/stdio/docs
+        resourcePolicyUri: http://localhost:3000/stdio/policies
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -129,7 +129,7 @@ binds:
 # WHAT THIS TEST VALIDATES:
 #   * The Authorization Server Proxy mcpAuthentication example (issuer, audiences,
 #     keycloak provider, resourceMetadata, jwks) is accepted by agentgateway in
-#     both the simplified MCP (mcp) and routing-based (binds) forms.
+#     both the simplified MCP (mcp) and routing-based (gateways) forms.
 #   * The test points jwks at a local file instead of the displayed IdP URL so it
 #     runs without a live identity provider.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
@@ -168,44 +168,44 @@ agentgateway -f proxy-mcp.yaml --validate-only
 
 cat <<'EOF' > proxy-routing.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      - path:
-          exact: /.well-known/oauth-authorization-server/mcp
-      - path:
-          exact: /.well-known/oauth-authorization-server/mcp/client-registration
-      policies:
-        mcpAuthentication:
-          issuer: http://localhost:7080/realms/mcp
-          audiences: ["http://localhost:3000/mcp"]
-          jwks:
-            file: ./manifests/jwt/pub-key
-          provider:
-            keycloak: {}
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - read:all
-            bearerMethodsSupported:
-            - header
-            - body
-            - query
-            resourceDocumentation: http://localhost:3000/stdio/docs
-            resourcePolicyUri: http://localhost:3000/stdio/policies
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  - path:
+      exact: /.well-known/oauth-authorization-server/mcp
+  - path:
+      exact: /.well-known/oauth-authorization-server/mcp/client-registration
+  policies:
+    mcpAuthentication:
+      issuer: http://localhost:7080/realms/mcp
+      audiences: ["http://localhost:3000/mcp"]
+      jwks:
+        file: ./manifests/jwt/pub-key
+      provider:
+        keycloak: {}
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - read:all
+        bearerMethodsSupported:
+        - header
+        - body
+        - query
+        resourceDocumentation: http://localhost:3000/stdio/docs
+        resourcePolicyUri: http://localhost:3000/stdio/policies
 EOF
 agentgateway -f proxy-routing.yaml --validate-only
 {{< /doc-test >}}
@@ -255,40 +255,40 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      - path:
-          pathPrefix: /.well-known/oauth-authorization-server/mcp
-      policies:
-        mcpAuthentication:
-          issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
-          audiences:
-          - api://<client-id>
-          - <client-id>
-          provider:
-            entra: {}
-          clientId: <client-id>
-          clientSecret: <client-secret>
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - api://<client-id>/mcp_access
-            bearerMethodsSupported:
-            - header
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  - path:
+      pathPrefix: /.well-known/oauth-authorization-server/mcp
+  policies:
+    mcpAuthentication:
+      issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
+      audiences:
+      - api://<client-id>
+      - <client-id>
+      provider:
+        entra: {}
+      clientId: <client-id>
+      clientSecret: <client-secret>
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - api://<client-id>/mcp_access
+        bearerMethodsSupported:
+        - header
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -300,7 +300,7 @@ For end-to-end setup, including registering the Entra app and connecting an MCP 
 #   * The Microsoft Entra ID mcpAuthentication example (entra provider, clientId,
 #     clientSecret, dual audiences, and the oauth-authorization-server pathPrefix
 #     match) is accepted by agentgateway in both the simplified MCP (mcp) and
-#     routing-based (binds) forms.
+#     routing-based (gateways) forms.
 #   * The test points jwks at a local file instead of the derived Entra URL so it
 #     runs without a live identity provider.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
@@ -339,42 +339,42 @@ agentgateway -f entra-mcp.yaml --validate-only
 
 cat <<'EOF' > entra-routing.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      - path:
-          pathPrefix: /.well-known/oauth-authorization-server/mcp
-      policies:
-        mcpAuthentication:
-          issuer: https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0
-          audiences:
-          - api://client-id-guid
-          - client-id-guid
-          provider:
-            entra: {}
-          clientId: client-id-guid
-          clientSecret: s3cret
-          jwks:
-            file: ./manifests/jwt/pub-key
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - api://client-id-guid/mcp_access
-            bearerMethodsSupported:
-            - header
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  - path:
+      pathPrefix: /.well-known/oauth-authorization-server/mcp
+  policies:
+    mcpAuthentication:
+      issuer: https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0
+      audiences:
+      - api://client-id-guid
+      - client-id-guid
+      provider:
+        entra: {}
+      clientId: client-id-guid
+      clientSecret: s3cret
+      jwks:
+        file: ./manifests/jwt/pub-key
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - api://client-id-guid/mcp_access
+        bearerMethodsSupported:
+        - header
 EOF
 agentgateway -f entra-routing.yaml --validate-only
 {{< /doc-test >}}
@@ -413,36 +413,36 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      policies:
-        mcpAuthentication:
-          issuer: http://localhost:9000
-          audiences: ["http://localhost:3000/mcp"]
-          jwks:
-            url: http://localhost:9000/.well-known/jwks.json
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - read:all
-            bearerMethodsSupported:
-            - header
-            - body
-            - query
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  policies:
+    mcpAuthentication:
+      issuer: http://localhost:9000
+      audiences: ["http://localhost:3000/mcp"]
+      jwks:
+        url: http://localhost:9000/.well-known/jwks.json
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - read:all
+        bearerMethodsSupported:
+        - header
+        - body
+        - query
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -451,7 +451,7 @@ binds:
 # WHAT THIS TEST VALIDATES:
 #   * The Resource Server Only mcpAuthentication example (issuer, audiences, jwks,
 #     resourceMetadata) is accepted by agentgateway in both the simplified MCP
-#     (mcp) and routing-based (binds) forms.
+#     (mcp) and routing-based (gateways) forms.
 #   * The test points jwks at a local file instead of the displayed IdP URL so it
 #     runs without a live identity provider.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
@@ -487,36 +487,36 @@ agentgateway -f rsonly-mcp.yaml --validate-only
 
 cat <<'EOF' > rsonly-routing.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      policies:
-        mcpAuthentication:
-          issuer: http://localhost:9000
-          audiences: ["http://localhost:3000/mcp"]
-          jwks:
-            file: ./manifests/jwt/pub-key
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - read:all
-            bearerMethodsSupported:
-            - header
-            - body
-            - query
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  policies:
+    mcpAuthentication:
+      issuer: http://localhost:9000
+      audiences: ["http://localhost:3000/mcp"]
+      jwks:
+        file: ./manifests/jwt/pub-key
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - read:all
+        bearerMethodsSupported:
+        - header
+        - body
+        - query
 EOF
 agentgateway -f rsonly-routing.yaml --validate-only
 {{< /doc-test >}}

--- a/content/docs/standalone/main/configuration/security/mcp-authz.md
+++ b/content/docs/standalone/main/configuration/security/mcp-authz.md
@@ -50,26 +50,26 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        mcpAuthorization:
-          rules:
-          # Allow anyone to call 'echo'
-          - 'mcp.tool.name == "echo"'
-          # Only the test-user can call 'add'
-          - 'jwt.sub == "test-user" && mcp.tool.name == "add"'
-          # Any authenticated user with the claim `nested.key == value` can access 'printEnv'
-          - 'mcp.tool.name == "printEnv" && jwt.nested.key == "value"'
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    mcpAuthorization:
+      rules:
+      # Allow anyone to call 'echo'
+      - 'mcp.tool.name == "echo"'
+      # Only the test-user can call 'add'
+      - 'jwt.sub == "test-user" && mcp.tool.name == "add"'
+      # Any authenticated user with the claim `nested.key == value` can access 'printEnv'
+      - 'mcp.tool.name == "printEnv" && jwt.nested.key == "value"'
+  backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -86,26 +86,26 @@ binds:
 #   * The tool-arguments fragment later on the page is not a standalone config.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        mcpAuthorization:
-          rules:
-          # Allow anyone to call 'echo'
-          - 'mcp.tool.name == "echo"'
-          # Only the test-user can call 'add'
-          - 'jwt.sub == "test-user" && mcp.tool.name == "add"'
-          # Any authenticated user with the claim `nested.key == value` can access 'printEnv'
-          - 'mcp.tool.name == "printEnv" && jwt.nested.key == "value"'
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    mcpAuthorization:
+      rules:
+      # Allow anyone to call 'echo'
+      - 'mcp.tool.name == "echo"'
+      # Only the test-user can call 'add'
+      - 'jwt.sub == "test-user" && mcp.tool.name == "add"'
+      # Any authenticated user with the claim `nested.key == value` can access 'printEnv'
+      - 'mcp.tool.name == "printEnv" && jwt.nested.key == "value"'
+  backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
 EOF
 
 cat <<'EOF' > config-mcp.yaml

--- a/content/docs/standalone/main/configuration/security/network-authz.md
+++ b/content/docs/standalone/main/configuration/security/network-authz.md
@@ -23,12 +23,12 @@ frontendPolicies:
     - deny: 'source.address == "192.168.1.100"'
     - require: 'source.port > 1024'
 
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
 ```
 
 ## Rules
@@ -90,16 +90,16 @@ frontendPolicies:
     rules:
     - allow: 'cidr("10.0.0.0/8").containsIP(source.address)'
 
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-      policies:
-        authorization:
-          rules:
-          - require: 'jwt.aud == "my-service"'
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+  policies:
+    authorization:
+      rules:
+      - require: 'jwt.aud == "my-service"'
 ```
 
 In this example, only connections from the `10.0.0.0/8` range are accepted at the network level, and those connections must also present a valid JWT with the correct audience claim.

--- a/content/docs/standalone/main/configuration/security/oidc.md
+++ b/content/docs/standalone/main/configuration/security/oidc.md
@@ -109,24 +109,24 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:18080
-      matches:
-      - path:
-          pathPrefix: /
-      policies:
-        oidc:
-          issuer: http://localhost:7080/realms/agentgateway
-          clientId: agentgateway-browser
-          clientSecret: agentgateway-secret
-          redirectURI: http://localhost:3000/oauth/callback
-          scopes:
-          - profile
-          - email
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:18080
+  matches:
+  - path:
+      pathPrefix: /
+  policies:
+    oidc:
+      issuer: http://localhost:7080/realms/agentgateway
+      clientId: agentgateway-browser
+      clientSecret: agentgateway-secret
+      redirectURI: http://localhost:3000/oauth/callback
+      scopes:
+      - profile
+      - email
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -180,24 +180,24 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:18080
-      matches:
-      - path:
-          pathPrefix: /
-      policies:
-        oidc:
-          issuer: http://keycloak.example.com/realms/myrealm
-          clientId: agentgateway-browser
-          clientSecret: my-client-secret
-          redirectURI: http://localhost:3000/oauth/callback
-          scopes:
-          - profile
-          - email
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:18080
+  matches:
+  - path:
+      pathPrefix: /
+  policies:
+    oidc:
+      issuer: http://keycloak.example.com/realms/myrealm
+      clientId: agentgateway-browser
+      clientSecret: my-client-secret
+      redirectURI: http://localhost:3000/oauth/callback
+      scopes:
+      - profile
+      - email
 ```
 {{< /tab >}}
 {{< tab name="traffic-oidc example" >}}

--- a/content/docs/standalone/main/configuration/static-configuration.md
+++ b/content/docs/standalone/main/configuration/static-configuration.md
@@ -4,7 +4,7 @@ weight: 10
 description: Configure static settings that are applied at startup time.
 ---
 
-Most agentgateway configurations dynamically update as you make changes to the binds, policies, backends, and so on. 
+Most agentgateway configurations dynamically update as you make changes to the gateways, routes, policies, backends, and so on. 
 
 However, a few configurations are statically configured at startup. These static configurations are under the `config` section.
 
@@ -14,5 +14,5 @@ The following table shows the `config` file schema for static configurations at 
 
 {{% github-table url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/schema/config.md" 
    section="Configuration File Schema"
-   exclude="^\\|.(binds|frontendPolicies|policies|services|workloads|backends|llm|mcp|routeGroups)"
+   exclude="^\\|.(gateways|routes|tcpRoutes|ui|binds|frontendPolicies|policies|services|workloads|backends|llm|mcp|routeGroups)"
 %}}

--- a/content/docs/standalone/main/configuration/traffic-management/_index.md
+++ b/content/docs/standalone/main/configuration/traffic-management/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Traffic management
-weight: 40
+weight: 50
 description: Control traffic with matching, redirects, body buffering, rewrites, and transformations.
 prev: /configuration/backends
 next: /configuration/resiliency

--- a/content/docs/standalone/main/configuration/traffic-management/buffer.md
+++ b/content/docs/standalone/main/configuration/traffic-management/buffer.md
@@ -29,16 +29,16 @@ Use a `policies` block to configure body buffering at the listener, route, or ba
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: localhost:8080
-        policies:
-          buffer:
-            request:
-              maxBytes: 64Ki
-            response:
-              maxBytes: 256Ki
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - host: localhost:8080
+    policies:
+      buffer:
+        request:
+          maxBytes: 64Ki
+        response:
+          maxBytes: 256Ki
 ```

--- a/content/docs/standalone/main/configuration/traffic-management/direct-response.md
+++ b/content/docs/standalone/main/configuration/traffic-management/direct-response.md
@@ -46,14 +46,14 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        directResponse:
-          body: "Not found!"
-          status: 404
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    directResponse:
+      body: "Not found!"
+      status: 404
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -61,14 +61,14 @@ binds:
 {{< doc-test paths="direct-response" >}}
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        directResponse:
-          body: "Not found!"
-          status: 404
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    directResponse:
+      body: "Not found!"
+      status: 404
 EOF
 
 cat <<'EOF' > config-mcp.yaml

--- a/content/docs/standalone/main/configuration/traffic-management/extproc.md
+++ b/content/docs/standalone/main/configuration/traffic-management/extproc.md
@@ -69,23 +69,23 @@ External processing is applied at the route level.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-         name: openai
-         provider:
-           openAI:
-             # Optional; overrides the model in requests
-             model: gpt-3.5-turbo
-      policies:
-        backendAuth:
-          key: "$OPEN_AI_APIKEY"
-        extProc:
-          host: "extproc.com:9000"
-          failureMode: failClosed
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+     name: openai
+     provider:
+       openAI:
+         # Optional; overrides the model in requests
+         model: gpt-3.5-turbo
+  policies:
+    backendAuth:
+      key: "$OPEN_AI_APIKEY"
+    extProc:
+      host: "extproc.com:9000"
+      failureMode: failClosed
 ```
 
 ## Configure processing options
@@ -110,58 +110,58 @@ The following example sends headers and trailers, buffers request bodies up to t
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: default
-            sse:
-              host: mcp.example.com
-              port: 8080
-      policies:
-        extProc:
-          host: "extproc.com:9000"
-          failureMode: failClosed
-          processingOptions:
-            requestHeaderMode: send
-            responseHeaderMode: send
-            requestBodyMode: bufferedPartial
-            responseBodyMode: none
-            requestTrailerMode: send
-            responseTrailerMode: send
-            allowModeOverride: true
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: default
+        sse:
+          host: mcp.example.com
+          port: 8080
+  policies:
+    extProc:
+      host: "extproc.com:9000"
+      failureMode: failClosed
+      processingOptions:
+        requestHeaderMode: send
+        responseHeaderMode: send
+        requestBodyMode: bufferedPartial
+        responseBodyMode: none
+        requestTrailerMode: send
+        responseTrailerMode: send
+        allowModeOverride: true
 ```
 
 You can also set `processingOptions` inside a conditional ExtProc policy. Each conditional policy entry can use different phase settings.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: default
-            sse:
-              host: mcp.example.com
-              port: 8080
-      policies:
-        extProc:
-          conditional:
-          - condition: 'request.path.startsWith("/upload")'
-            host: "extproc.com:9000"
-            processingOptions:
-              requestBodyMode: buffered
-              responseBodyMode: none
-          - host: "extproc.com:9000"
-            processingOptions:
-              requestBodyMode: none
-              responseBodyMode: none
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: default
+        sse:
+          host: mcp.example.com
+          port: 8080
+  policies:
+    extProc:
+      conditional:
+      - condition: 'request.path.startsWith("/upload")'
+        host: "extproc.com:9000"
+        processingOptions:
+          requestBodyMode: buffered
+          responseBodyMode: none
+      - host: "extproc.com:9000"
+        processingOptions:
+          requestBodyMode: none
+          responseBodyMode: none
 ```
 
 ## Conditional execution

--- a/content/docs/standalone/main/configuration/traffic-management/manipulation.md
+++ b/content/docs/standalone/main/configuration/traffic-management/manipulation.md
@@ -44,18 +44,18 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        requestHeaderModifier:
-          add:
-            x-req-added: value
-          remove:
-          - x-remove-me
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    requestHeaderModifier:
+      add:
+        x-req-added: value
+      remove:
+      - x-remove-me
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -63,24 +63,24 @@ binds:
 {{< doc-test paths="manipulation" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The requestHeaderModifier example config is accepted by agentgateway in
-#     both the routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     both the routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That headers are actually added/removed at runtime — requires a backend
 #     the page omits to forward to and inspect.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        requestHeaderModifier:
-          add:
-            x-req-added: value
-          remove:
-          - x-remove-me
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    requestHeaderModifier:
+      add:
+        x-req-added: value
+      remove:
+      - x-remove-me
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/traffic-management/matching.md
+++ b/content/docs/standalone/main/configuration/traffic-management/matching.md
@@ -10,7 +10,7 @@ test:
 
 Based on the route schema (see the [configuration reference]({{< link-hextra path="/reference/configuration/" >}}) for the full field reference and [schema validation]({{< link-hextra path="/reference/configuration/validation/" >}}) for IDE integration), you can configure the following {{< gloss "Matching" >}}matching{{< /gloss >}} conditions for HTTP or TCP routes.
 
-Request matching is a routing-based feature: routes and their match conditions are configured under `binds`. The simplified `llm` configuration supports header-based model matching (`llm.models[].matches`), but path, method, and query matching require routing-based configuration. For more information about the configuration styles, see [Routing-based configuration]({{< link-hextra path="/llm/configuration-modes/" >}}).
+Request matching is a routing-based feature: routes and their match conditions are configured in the top-level `routes` section and attached to a gateway. The simplified `llm` configuration supports header-based model matching (`llm.models[].matches`), but path, method, and query matching require routing-based configuration. For more information about the configuration styles, see [Routing-based configuration]({{< link-hextra path="/llm/configuration-modes/" >}}).
 
 {{< doc-test paths="matching" >}}
 {{< reuse "agw-docs/snippets/install-agentgateway-binary.md" >}}
@@ -42,46 +42,46 @@ Only one of `exact`, `pathPrefix`, or `regex` can be specified per path matcher.
 {{< tab name="Exact path matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: api-exact
-      matches:
-      - path:
-          exact: "/api/v1/users"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: api-exact
+  matches:
+  - path:
+      exact: "/api/v1/users"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Prefix path matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: api-prefix
-      matches:
-      - path:
-          pathPrefix: "/api/v1"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: api-prefix
+  matches:
+  - path:
+      pathPrefix: "/api/v1"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Regex path matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: api-regex
-      matches:
-      - path:
-          regex: ["^/api/v[0-9]+/users$", 0]
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: api-regex
+  matches:
+  - path:
+      regex: ["^/api/v[0-9]+/users$", 0]
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -101,61 +101,61 @@ Match incoming requests based on HTTP headers included in the request.
 {{< tab name="Exact header matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: auth-exact
-      matches:
-      - path:
-          pathPrefix: "/api"
-        headers:
-        - name: "Authorization"
-          value:
-            exact: "Bearer abc123token"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: auth-exact
+  matches:
+  - path:
+      pathPrefix: "/api"
+    headers:
+    - name: "Authorization"
+      value:
+        exact: "Bearer abc123token"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Regex header matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: auth-regex
-      matches:
-      - path:
-          pathPrefix: "/api"
-        headers:
-        - name: "Authorization"
-          value:
-            regex: "^Bearer .*"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: auth-regex
+  matches:
+  - path:
+      pathPrefix: "/api"
+    headers:
+    - name: "Authorization"
+      value:
+        regex: "^Bearer .*"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Multiple header matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: multi-header
-      matches:
-      - path:
-          pathPrefix: "/api"
-        headers:
-        - name: "Authorization"
-          value:
-            regex: "^Bearer .*"
-        - name: "Content-Type"
-          value:
-            exact: "application/json"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: multi-header
+  matches:
+  - path:
+      pathPrefix: "/api"
+    headers:
+    - name: "Authorization"
+      value:
+        regex: "^Bearer .*"
+    - name: "Content-Type"
+      value:
+        exact: "application/json"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -174,56 +174,56 @@ Optionally restrict matches to specific HTTP methods.
 {{< tab name="GET method matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: get-only
-      matches:
-      - path:
-          pathPrefix: "/api"
-        method: "GET"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: get-only
+  matches:
+  - path:
+      pathPrefix: "/api"
+    method: "GET"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="POST method matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: post-only
-      matches:
-      - path:
-          pathPrefix: "/api/users"
-        method: "POST"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: post-only
+  matches:
+  - path:
+      pathPrefix: "/api/users"
+    method: "POST"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Multiple methods with different backends" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: read-operations
-      matches:
-      - path:
-          pathPrefix: "/api/users"
-        method: "GET"
-      backends:
-      - host: read-api.example.com:8080
-    - name: write-operations
-      matches:
-      - path:
-          pathPrefix: "/api/users"
-        method: "POST"
-      backends:
-      - host: write-api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: read-operations
+  matches:
+  - path:
+      pathPrefix: "/api/users"
+    method: "GET"
+  backends:
+  - host: read-api.example.com:8080
+- name: write-operations
+  matches:
+  - path:
+      pathPrefix: "/api/users"
+    method: "POST"
+  backends:
+  - host: write-api.example.com:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -243,61 +243,61 @@ Match on query parameters, either by exact value or regex.
 {{< tab name="Exact query parameter matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: version-exact
-      matches:
-      - path:
-          pathPrefix: "/api"
-        query:
-        - name: "version"
-          value:
-            exact: "v1"
-      backends:
-      - host: api-v1.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: version-exact
+  matches:
+  - path:
+      pathPrefix: "/api"
+    query:
+    - name: "version"
+      value:
+        exact: "v1"
+  backends:
+  - host: api-v1.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Regex query parameter matching" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: version-regex
-      matches:
-      - path:
-          pathPrefix: "/api"
-        query:
-        - name: "version"
-          value:
-            regex: "^v[0-9]+$"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: version-regex
+  matches:
+  - path:
+      pathPrefix: "/api"
+    query:
+    - name: "version"
+      value:
+        regex: "^v[0-9]+$"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< tab name="Multiple query parameters" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: multi-query
-      matches:
-      - path:
-          pathPrefix: "/api"
-        query:
-        - name: "version"
-          value:
-            exact: "v1"
-        - name: "format"
-          value:
-            regex: "^(json|xml)$"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: multi-query
+  matches:
+  - path:
+      pathPrefix: "/api"
+    query:
+    - name: "version"
+      value:
+        exact: "v1"
+    - name: "format"
+      value:
+        regex: "^(json|xml)$"
+  backends:
+  - host: api.example.com:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -308,25 +308,25 @@ You can combine multiple matching conditions to create a more specific route, su
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: comprehensive-match
-      matches:
-      - path:
-          pathPrefix: "/api/v1"
-        method: "GET"
-        headers:
-        - name: "Authorization"
-          value:
-            regex: "^Bearer .*"
-        query:
-        - name: "format"
-          value:
-            exact: "json"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: comprehensive-match
+  matches:
+  - path:
+      pathPrefix: "/api/v1"
+    method: "GET"
+    headers:
+    - name: "Authorization"
+      value:
+        regex: "^Bearer .*"
+    query:
+    - name: "format"
+      value:
+        exact: "json"
+  backends:
+  - host: api.example.com:8080
 ```
 
 {{< doc-test paths="matching" >}}
@@ -339,25 +339,25 @@ binds:
 #     header, method, query) are structurally analogous and not individually tested.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - name: comprehensive-match
-      matches:
-      - path:
-          pathPrefix: "/api/v1"
-        method: "GET"
-        headers:
-        - name: "Authorization"
-          value:
-            regex: "^Bearer .*"
-        query:
-        - name: "format"
-          value:
-            exact: "json"
-      backends:
-      - host: api.example.com:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- name: comprehensive-match
+  matches:
+  - path:
+      pathPrefix: "/api/v1"
+    method: "GET"
+    headers:
+    - name: "Authorization"
+      value:
+        regex: "^Bearer .*"
+    query:
+    - name: "format"
+      value:
+        exact: "json"
+  backends:
+  - host: api.example.com:8080
 EOF
 agentgateway -f config.yaml --validate-only
 {{< /doc-test >}}
@@ -372,17 +372,17 @@ Match incoming requests based on the hostname included in the request. This is p
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 5432
-  listeners:
-  - name: database-proxy
+gateways:
+  database-proxy:
+    port: 5432
     protocol: TCP
-    tcpRoutes:
-    - name: database-backend
-      hostnames:
-      - "db.example.com"
-      backends:
-      - host: postgres.example.com:5432
+tcpRoutes:
+- name: database-backend
+  gateways: [database-proxy]
+  hostnames:
+  - "db.example.com"
+  backends:
+  - host: postgres.example.com:5432
 ```
 
 ### Backend routing
@@ -397,20 +397,20 @@ If no weight is specified, the default is 1. Backends with a weight of 0 receive
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 6379
-  listeners:
-  - name: redis-proxy
+gateways:
+  redis-proxy:
+    port: 6379
     protocol: TCP
-    tcpRoutes:
-    - name: redis-cluster
-      backends:
-      - host: redis-1.example.com:6379
-        weight: 1
-      - host: redis-2.example.com:6379
-        weight: 2
-      - host: redis-3.example.com:6379
-        weight: 1
+tcpRoutes:
+- name: redis-cluster
+  gateways: [redis-proxy]
+  backends:
+  - host: redis-1.example.com:6379
+    weight: 1
+  - host: redis-2.example.com:6379
+    weight: 2
+  - host: redis-3.example.com:6379
+    weight: 1
 ```
 
 {{< doc-test paths="matching" >}}
@@ -423,20 +423,20 @@ binds:
 #     and not individually tested.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 6379
-  listeners:
-  - name: redis-proxy
+gateways:
+  redis-proxy:
+    port: 6379
     protocol: TCP
-    tcpRoutes:
-    - name: redis-cluster
-      backends:
-      - host: redis-1.example.com:6379
-        weight: 1
-      - host: redis-2.example.com:6379
-        weight: 2
-      - host: redis-3.example.com:6379
-        weight: 1
+tcpRoutes:
+- name: redis-cluster
+  gateways: [redis-proxy]
+  backends:
+  - host: redis-1.example.com:6379
+    weight: 1
+  - host: redis-2.example.com:6379
+    weight: 2
+  - host: redis-3.example.com:6379
+    weight: 1
 EOF
 agentgateway -f config2.yaml --validate-only
 {{< /doc-test >}}

--- a/content/docs/standalone/main/configuration/traffic-management/redirects.md
+++ b/content/docs/standalone/main/configuration/traffic-management/redirects.md
@@ -44,18 +44,18 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        requestRedirect:
-          scheme: https
-          authority:
-            full: example.com
-          path:
-            full: /new-path
-          status: 307
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    requestRedirect:
+      scheme: https
+      authority:
+        full: example.com
+      path:
+        full: /new-path
+      status: 307
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -63,24 +63,24 @@ binds:
 {{< doc-test paths="redirects" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The requestRedirect example config is accepted by agentgateway in both the
-#     routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That a 307 redirect is actually returned at runtime — requires sending a
 #     request and inspecting the response, which the page does not demonstrate.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        requestRedirect:
-          scheme: https
-          authority:
-            full: example.com
-          path:
-            full: /new-path
-          status: 307
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    requestRedirect:
+      scheme: https
+      authority:
+        full: example.com
+      path:
+        full: /new-path
+      status: 307
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/traffic-management/rewrites.md
+++ b/content/docs/standalone/main/configuration/traffic-management/rewrites.md
@@ -42,18 +42,18 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        urlRewrite:
-          authority:
-            full: example.com
-          path:
-            full: /new-path
-      backends:
-      - host: example.com:443
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    urlRewrite:
+      authority:
+        full: example.com
+      path:
+        full: /new-path
+  backends:
+  - host: example.com:443
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -61,24 +61,24 @@ binds:
 {{< doc-test paths="rewrites" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The urlRewrite example config is accepted by agentgateway in both the
-#     routing-based (binds) and simplified MCP (mcp.policies) forms.
+#     routing-based (gateways) and simplified MCP (mcp.policies) forms.
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That the hostname/path are actually rewritten at runtime — requires a
 #     backend the page omits to forward to and inspect.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        urlRewrite:
-          authority:
-            full: example.com
-          path:
-            full: /new-path
-      backends:
-      - host: example.com:443
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    urlRewrite:
+      authority:
+        full: example.com
+      path:
+        full: /new-path
+  backends:
+  - host: example.com:443
 EOF
 agentgateway -f config.yaml --validate-only
 

--- a/content/docs/standalone/main/configuration/traffic-management/route-delegation.md
+++ b/content/docs/standalone/main/configuration/traffic-management/route-delegation.md
@@ -64,17 +64,17 @@ In this example, a parent route matches the `/anything/team1` prefix and delegat
    ```sh
    cat > config.yaml <<'EOF'
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   binds:
-   - port: 3000
-     listeners:
-     - protocol: HTTP
-       routes:
-       - name: parent-team1
-         matches:
-         - path:
-             pathPrefix: /anything/team1
-         backends:
-         - routeGroup: team1-routes
+   gateways:
+     default:
+       port: 3000
+       protocol: HTTP
+   routes:
+   - name: parent-team1
+     matches:
+     - path:
+         pathPrefix: /anything/team1
+     backends:
+     - routeGroup: team1-routes
 
    routeGroups:
    - name: team1-routes
@@ -130,25 +130,25 @@ In this example, a parent route matches `/anything/team1` only when the `x-team`
    ```sh
    cat > config.yaml <<'EOF'
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   binds:
-   - port: 3000
-     listeners:
-     - protocol: HTTP
-       routes:
-       - name: parent-team1
-         matches:
-         - path:
-             pathPrefix: /anything/team1
-           headers:
-           - name: x-team
-             value:
-               exact: team1
-           query:
-           - name: env
-             value:
-               exact: prod
-         backends:
-         - routeGroup: team1-routes
+   gateways:
+     default:
+       port: 3000
+       protocol: HTTP
+   routes:
+   - name: parent-team1
+     matches:
+     - path:
+         pathPrefix: /anything/team1
+       headers:
+       - name: x-team
+         value:
+           exact: team1
+       query:
+       - name: env
+         value:
+           exact: prod
+     backends:
+     - routeGroup: team1-routes
 
    routeGroups:
    - name: team1-routes
@@ -208,17 +208,17 @@ In this example, a parent route delegates `/api` to a route group. One child han
    ```sh
    cat > config.yaml <<'EOF'
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   binds:
-   - port: 3000
-     listeners:
-     - protocol: HTTP
-       routes:
-       - name: parent-api
-         matches:
-         - path:
-             pathPrefix: /api
-         backends:
-         - routeGroup: api-routes
+   gateways:
+     default:
+       port: 3000
+       protocol: HTTP
+   routes:
+   - name: parent-api
+     matches:
+     - path:
+         pathPrefix: /api
+     backends:
+     - routeGroup: api-routes
 
    routeGroups:
    - name: api-routes
@@ -285,21 +285,21 @@ In this example, a parent route sets a `requestHeaderModifier` policy that adds 
    ```sh
    cat > config.yaml <<'EOF'
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   binds:
-   - port: 3000
-     listeners:
-     - protocol: HTTP
-       routes:
-       - name: parent-team1
-         matches:
-         - path:
-             pathPrefix: /anything/team1
-         policies:
-           requestHeaderModifier:
-             add:
-               x-parent: from-parent
-         backends:
-         - routeGroup: team1-routes
+   gateways:
+     default:
+       port: 3000
+       protocol: HTTP
+   routes:
+   - name: parent-team1
+     matches:
+     - path:
+         pathPrefix: /anything/team1
+     policies:
+       requestHeaderModifier:
+         add:
+           x-parent: from-parent
+     backends:
+     - routeGroup: team1-routes
 
    routeGroups:
    - name: team1-routes

--- a/content/docs/standalone/main/configuration/traffic-management/transformations.md
+++ b/content/docs/standalone/main/configuration/traffic-management/transformations.md
@@ -91,36 +91,36 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-         name: openai
-         provider:
-           openAI:
-             # Optional; overrides the model in requests
-             model: gpt-3.5-turbo
-      policies:
-        backendAuth:
-          key: "$OPEN_AI_APIKEY"
-        cors:
-          allowOrigins:
-            - "*"
-          allowHeaders:
-            - "*"
-        transformations:
-          request:
-            add:
-              x-request-path: request.path
-              x-client-ip: source.address
-          response:
-            add:
-              x-response-code: 'string(response.code)'
-            remove:
-            - server
-            - x-content-type-options
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+     name: openai
+     provider:
+       openAI:
+         # Optional; overrides the model in requests
+         model: gpt-3.5-turbo
+  policies:
+    backendAuth:
+      key: "$OPEN_AI_APIKEY"
+    cors:
+      allowOrigins:
+        - "*"
+      allowHeaders:
+        - "*"
+    transformations:
+      request:
+        add:
+          x-request-path: request.path
+          x-client-ip: source.address
+      response:
+        add:
+          x-response-code: 'string(response.code)'
+        remove:
+        - server
+        - x-content-type-options
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -128,43 +128,43 @@ binds:
 {{< doc-test paths="transformations" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The route-level header transformation example config is accepted by
-#     agentgateway in all three configuration forms: routing-based (binds),
+#     agentgateway in all three configuration forms: routing-based (gateways),
 #     simplified LLM (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * Runtime header rewriting and the AI backend call — requires a live OpenAI
 #     backend and a real API key the page omits.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-         name: openai
-         provider:
-           openAI:
-             # Optional; overrides the model in requests
-             model: gpt-3.5-turbo
-      policies:
-        backendAuth:
-          key: "$OPEN_AI_APIKEY"
-        cors:
-          allowOrigins:
-            - "*"
-          allowHeaders:
-            - "*"
-        transformations:
-          request:
-            add:
-              x-request-path: request.path
-              x-client-ip: source.address
-          response:
-            add:
-              x-response-code: 'string(response.code)'
-            remove:
-            - server
-            - x-content-type-options
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+     name: openai
+     provider:
+       openAI:
+         # Optional; overrides the model in requests
+         model: gpt-3.5-turbo
+  policies:
+    backendAuth:
+      key: "$OPEN_AI_APIKEY"
+    cors:
+      allowOrigins:
+        - "*"
+      allowHeaders:
+        - "*"
+    transformations:
+      request:
+        add:
+          x-request-path: request.path
+          x-client-ip: source.address
+      response:
+        add:
+          x-response-code: 'string(response.code)'
+        remove:
+        - server
+        - x-content-type-options
 EOF
 agentgateway -f config.yaml --validate-only
 
@@ -257,24 +257,23 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      transformations:
-        request:
-          add:
-            x-gateway: '"agentgateway"'
-    routes:
-    - policies:
-        backendAuth:
-          key: "$OPEN_AI_APIKEY"
-      backends:
-      - ai:
-         name: openai
-         provider:
-           openAI:
-             model: gpt-3.5-turbo
+gateways:
+  default:
+    port: 3000
+    transformations:
+      request:
+        add:
+          x-gateway: '"agentgateway"'
+routes:
+- policies:
+    backendAuth:
+      key: "$OPEN_AI_APIKEY"
+  backends:
+  - ai:
+     name: openai
+     provider:
+       openAI:
+         model: gpt-3.5-turbo
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -282,31 +281,30 @@ binds:
 {{< doc-test paths="transformations" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The listener-level header transformation example config is accepted by
-#     agentgateway in all three configuration forms: routing-based (binds),
+#     agentgateway in all three configuration forms: routing-based (gateways),
 #     simplified LLM (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * Runtime header injection and the AI backend call — requires a live OpenAI
 #     backend and a real API key the page omits.
 cat <<'EOF' > config2.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - policies:
-      transformations:
-        request:
-          add:
-            x-gateway: '"agentgateway"'
-    routes:
-    - policies:
-        backendAuth:
-          key: "$OPEN_AI_APIKEY"
-      backends:
-      - ai:
-         name: openai
-         provider:
-           openAI:
-             model: gpt-3.5-turbo
+gateways:
+  default:
+    port: 3000
+    transformations:
+      request:
+        add:
+          x-gateway: '"agentgateway"'
+routes:
+- policies:
+    backendAuth:
+      key: "$OPEN_AI_APIKEY"
+  backends:
+  - ai:
+     name: openai
+     provider:
+       openAI:
+         model: gpt-3.5-turbo
 EOF
 agentgateway -f config2.yaml --validate-only
 
@@ -395,20 +393,20 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        transformations:
-          request:
-            body: |
-              "Hello " + default(request.headers["x-user-name"], "guest")
-          response:
-            body: |
-              "Response code: " + string(response.code)
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    transformations:
+      request:
+        body: |
+          "Hello " + default(request.headers["x-user-name"], "guest")
+      response:
+        body: |
+          "Response code: " + string(response.code)
+  backends:
+  - host: localhost:8080
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -416,27 +414,27 @@ binds:
 {{< doc-test paths="transformations" >}}
 # WHAT THIS TEST VALIDATES:
 #   * The body transformation example config is accepted by agentgateway in all
-#     three configuration forms: routing-based (binds), simplified LLM
+#     three configuration forms: routing-based (gateways), simplified LLM
 #     (llm.policies), and simplified MCP (mcp.policies).
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * Runtime body rewriting — requires a backend the page omits to forward to
 #     and inspect.
 cat <<'EOF' > config3.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - policies:
-        transformations:
-          request:
-            body: |
-              "Hello " + default(request.headers["x-user-name"], "guest")
-          response:
-            body: |
-              "Response code: " + string(response.code)
-      backends:
-      - host: localhost:8080
+gateways:
+  default:
+    port: 3000
+routes:
+- policies:
+    transformations:
+      request:
+        body: |
+          "Hello " + default(request.headers["x-user-name"], "guest")
+      response:
+        body: |
+          "Response code: " + string(response.code)
+  backends:
+  - host: localhost:8080
 EOF
 agentgateway -f config3.yaml --validate-only
 

--- a/content/docs/standalone/main/integrations/auth/auth0.md
+++ b/content/docs/standalone/main/integrations/auth/auth0.md
@@ -20,25 +20,25 @@ Configure agentgateway to validate Auth0 JWTs:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: my-server
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        mcpAuthentication:
-          mode: strict
-          issuer: https://your-tenant.auth0.com/
-          audiences:
-          - https://api.example.com
-          jwks:
-            url: https://your-tenant.auth0.com/.well-known/jwks.json
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: my-server
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  policies:
+    mcpAuthentication:
+      mode: strict
+      issuer: https://your-tenant.auth0.com/
+      audiences:
+      - https://api.example.com
+      jwks:
+        url: https://your-tenant.auth0.com/.well-known/jwks.json
 ```
 
 ## Auth0 setup

--- a/content/docs/standalone/main/integrations/auth/entra.md
+++ b/content/docs/standalone/main/integrations/auth/entra.md
@@ -120,44 +120,44 @@ mcp:
 {{< tab name="Routing-based" >}}
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: tools
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      matches:
-      - path:
-          exact: /mcp
-      - path:
-          exact: /.well-known/oauth-protected-resource/mcp
-      - path:
-          pathPrefix: /.well-known/oauth-authorization-server/mcp
-      policies:
-        cors:
-          allowOrigins: ["*"]
-          allowHeaders: ["*"]
-          exposeHeaders: ["Mcp-Session-Id"]
-        mcpAuthentication:
-          issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
-          audiences:
-          - api://<client-id>
-          - <client-id>
-          provider:
-            entra: {}
-          clientId: <client-id>
-          clientSecret: <client-secret>
-          resourceMetadata:
-            resource: http://localhost:3000/mcp
-            scopesSupported:
-            - api://<client-id>/mcp_access
-            bearerMethodsSupported:
-            - header
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: tools
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  matches:
+  - path:
+      exact: /mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/mcp
+  - path:
+      pathPrefix: /.well-known/oauth-authorization-server/mcp
+  policies:
+    cors:
+      allowOrigins: ["*"]
+      allowHeaders: ["*"]
+      exposeHeaders: ["Mcp-Session-Id"]
+    mcpAuthentication:
+      issuer: https://login.microsoftonline.com/<tenant-id>/v2.0
+      audiences:
+      - api://<client-id>
+      - <client-id>
+      provider:
+        entra: {}
+      clientId: <client-id>
+      clientSecret: <client-secret>
+      resourceMetadata:
+        resource: http://localhost:3000/mcp
+        scopesSupported:
+        - api://<client-id>/mcp_access
+        bearerMethodsSupported:
+        - header
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/content/docs/standalone/main/integrations/auth/keycloak.md
+++ b/content/docs/standalone/main/integrations/auth/keycloak.md
@@ -19,25 +19,25 @@ Configure agentgateway to validate Keycloak JWTs:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: my-server
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        mcpAuthentication:
-          mode: strict
-          issuer: https://keycloak.example.com/realms/myrealm
-          audiences:
-          - agentgateway
-          jwks:
-            url: https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: my-server
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  policies:
+    mcpAuthentication:
+      mode: strict
+      issuer: https://keycloak.example.com/realms/myrealm
+      audiences:
+      - agentgateway
+      jwks:
+        url: https://keycloak.example.com/realms/myrealm/protocol/openid-connect/certs
 ```
 
 ## Docker Compose example

--- a/content/docs/standalone/main/integrations/auth/oauth2-proxy.md
+++ b/content/docs/standalone/main/integrations/auth/oauth2-proxy.md
@@ -80,55 +80,54 @@ frontendPolicies:
       github.user: 'extauthz.githubUser'
       github.email: 'extauthz.githubEmail'
 
-binds:
-- port: 3000
-  listeners:
-  - name: default
+gateways:
+  default:
+    port: 3000
     protocol: HTTP
-    routes:
-    # Route OAuth2 Proxy endpoints (login, callback, and so on)
-    - name: oauth2-proxy
-      matches:
-      - path:
-          pathPrefix: /oauth2
-      policies:
-        urlRewrite:
-          authority: none
-      backends:
-      - host: localhost:4180
+routes:
+# Route OAuth2 Proxy endpoints (login, callback, and so on)
+- name: oauth2-proxy
+  matches:
+  - path:
+      pathPrefix: /oauth2
+  policies:
+    urlRewrite:
+      authority: none
+  backends:
+  - host: localhost:4180
 
-    # Protected MCP application
-    - name: application
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        cors:
-          allowOrigins: ["*"]
-          allowHeaders: ["*"]
-          exposeHeaders: ["Mcp-Session-Id"]
-        extAuthz:
-          host: localhost:4180
-          includeRequestHeaders:
-          - cookie
-          protocol:
-            http:
-              # Check authentication status
-              path: '"/oauth2/auth"'
-              # Redirect unauthenticated users to login
-              redirect: '"/oauth2/start?rd=" + request.path'
-              # Extract user info from OAuth2 Proxy response headers
-              metadata:
-                githubUser: response.headers["x-auth-request-user"]
-                githubEmail: response.headers["x-auth-request-email"]
-              addRequestHeaders:
-                x-forwarded-host: request.host
-              includeResponseHeaders:
-              - x-auth-request-user
+# Protected MCP application
+- name: application
+  backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  policies:
+    cors:
+      allowOrigins: ["*"]
+      allowHeaders: ["*"]
+      exposeHeaders: ["Mcp-Session-Id"]
+    extAuthz:
+      host: localhost:4180
+      includeRequestHeaders:
+      - cookie
+      protocol:
+        http:
+          # Check authentication status
+          path: '"/oauth2/auth"'
+          # Redirect unauthenticated users to login
+          redirect: '"/oauth2/start?rd=" + request.path'
+          # Extract user info from OAuth2 Proxy response headers
+          metadata:
+            githubUser: response.headers["x-auth-request-user"]
+            githubEmail: response.headers["x-auth-request-email"]
+          addRequestHeaders:
+            x-forwarded-host: request.host
+          includeResponseHeaders:
+          - x-auth-request-user
 ```
 
 The following table describes the key settings in the configuration.

--- a/content/docs/standalone/main/integrations/auth/okta.md
+++ b/content/docs/standalone/main/integrations/auth/okta.md
@@ -20,25 +20,25 @@ Configure agentgateway to validate Okta JWTs:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: my-server
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        mcpAuthentication:
-          mode: strict
-          issuer: https://your-org.okta.com/oauth2/default
-          audiences:
-          - api://agentgateway
-          jwks:
-            url: https://your-org.okta.com/oauth2/default/v1/keys
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - mcp:
+      targets:
+      - name: my-server
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  policies:
+    mcpAuthentication:
+      mode: strict
+      issuer: https://your-org.okta.com/oauth2/default
+      audiences:
+      - api://agentgateway
+      jwks:
+        url: https://your-org.okta.com/oauth2/default/v1/keys
 ```
 
 ## Okta setup

--- a/content/docs/standalone/main/integrations/auth/tailscale.md
+++ b/content/docs/standalone/main/integrations/auth/tailscale.md
@@ -47,36 +47,35 @@ frontendPolicies:
       tailscale.node: extauthz.tailscaleNode
       tailscale.email: extauthz.tailscaleEmail
 
-binds:
-- port: 3000
-  listeners:
-  - name: default
+gateways:
+  default:
+    port: 3000
     protocol: HTTP
-    routes:
-    - name: application
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        cors:
-          allowOrigins: ["*"]
-          allowHeaders: ["*"]
-          exposeHeaders: ["Mcp-Session-Id"]
-        extAuthz:
-          host: unix:/run/tailscale/tailscaled.sock
-          protocol:
-            http:
-              path: |
-                "/localapi/v0/whois?addr=" + source.address
-              addRequestHeaders:
-                :authority: '"local-tailscaled.sock"'
-              metadata:
-                tailscaleNode: json(response.body).Node.Name
-                tailscaleEmail: json(response.body).UserProfile.LoginName
+routes:
+- name: application
+  backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  policies:
+    cors:
+      allowOrigins: ["*"]
+      allowHeaders: ["*"]
+      exposeHeaders: ["Mcp-Session-Id"]
+    extAuthz:
+      host: unix:/run/tailscale/tailscaled.sock
+      protocol:
+        http:
+          path: |
+            "/localapi/v0/whois?addr=" + source.address
+          addRequestHeaders:
+            :authority: '"local-tailscaled.sock"'
+          metadata:
+            tailscaleNode: json(response.body).Node.Name
+            tailscaleEmail: json(response.body).UserProfile.LoginName
 ```
 {{% /tab %}}
 {{% tab name="macOS" %}}
@@ -88,36 +87,35 @@ frontendPolicies:
       tailscale.node: extauthz.tailscaleNode
       tailscale.email: extauthz.tailscaleEmail
 
-binds:
-- port: 3000
-  listeners:
-  - name: default
+gateways:
+  default:
+    port: 3000
     protocol: HTTP
-    routes:
-    - name: application
-      backends:
-      - mcp:
-          targets:
-          - name: everything
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
-      policies:
-        cors:
-          allowOrigins: ["*"]
-          allowHeaders: ["*"]
-          exposeHeaders: ["Mcp-Session-Id"]
-        extAuthz:
-          host: unix:/var/run/tailscale/tailscaled.sock
-          protocol:
-            http:
-              path: |
-                "/localapi/v0/whois?addr=" + source.address
-              addRequestHeaders:
-                :authority: '"local-tailscaled.sock"'
-              metadata:
-                tailscaleNode: json(response.body).Node.Name
-                tailscaleEmail: json(response.body).UserProfile.LoginName
+routes:
+- name: application
+  backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
+  policies:
+    cors:
+      allowOrigins: ["*"]
+      allowHeaders: ["*"]
+      exposeHeaders: ["Mcp-Session-Id"]
+    extAuthz:
+      host: unix:/var/run/tailscale/tailscaled.sock
+      protocol:
+        http:
+          path: |
+            "/localapi/v0/whois?addr=" + source.address
+          addRequestHeaders:
+            :authority: '"local-tailscaled.sock"'
+          metadata:
+            tailscaleNode: json(response.body).Node.Name
+            tailscaleEmail: json(response.body).UserProfile.LoginName
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/docs/standalone/main/integrations/llm-observability/_index.md
+++ b/content/docs/standalone/main/integrations/llm-observability/_index.md
@@ -28,19 +28,19 @@ config:
     otlpEndpoint: http://localhost:4317
     randomSampling: true
 
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-4o-mini
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-4o-mini
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 Agentgateway automatically includes these LLM-specific trace attributes:

--- a/content/docs/standalone/main/integrations/llm-observability/langfuse.md
+++ b/content/docs/standalone/main/integrations/llm-observability/langfuse.md
@@ -44,19 +44,19 @@ config:
     otlpEndpoint: https://cloud.langfuse.com/api/public/otel
     randomSampling: true
 
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-4o-mini
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-4o-mini
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 ### Authentication

--- a/content/docs/standalone/main/integrations/llm-observability/langsmith.md
+++ b/content/docs/standalone/main/integrations/llm-observability/langsmith.md
@@ -30,19 +30,19 @@ config:
     otlpEndpoint: https://api.smith.langchain.com/otel
     randomSampling: true
 
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-4o-mini
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-4o-mini
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 ### Authentication

--- a/content/docs/standalone/main/integrations/llm-observability/phoenix.md
+++ b/content/docs/standalone/main/integrations/llm-observability/phoenix.md
@@ -44,19 +44,19 @@ config:
     otlpEndpoint: http://localhost:4317
     randomSampling: true
 
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-4o-mini
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-4o-mini
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 ## Docker Compose example

--- a/content/docs/standalone/main/integrations/networking/cert-manager.md
+++ b/content/docs/standalone/main/integrations/networking/cert-manager.md
@@ -96,15 +96,14 @@ Then reference it in your agentgateway config:
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 gateways:
-  https:
+  default:
     port: 443
     protocol: HTTPS
     tls:
       cert: /certs/tls.crt
       key: /certs/tls.key
 routes:
-- gateways: [https]
-  backends:
+- backends:
   - mcp:
       targets:
       - name: my-server

--- a/content/docs/standalone/main/integrations/networking/cert-manager.md
+++ b/content/docs/standalone/main/integrations/networking/cert-manager.md
@@ -95,22 +95,22 @@ Then reference it in your agentgateway config:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 443
-  listeners:
-  - name: https
+gateways:
+  https:
+    port: 443
     protocol: HTTPS
     tls:
       cert: /certs/tls.crt
       key: /certs/tls.key
-    routes:
-    - backends:
-      - mcp:
-          targets:
-          - name: my-server
-            stdio:
-              cmd: npx
-              args: ["@modelcontextprotocol/server-everything"]
+routes:
+- gateways: [https]
+  backends:
+  - mcp:
+      targets:
+      - name: my-server
+        stdio:
+          cmd: npx
+          args: ["@modelcontextprotocol/server-everything"]
 ```
 
 ## Self-signed certificates for development

--- a/content/docs/standalone/main/llm/about.md
+++ b/content/docs/standalone/main/llm/about.md
@@ -127,7 +127,7 @@ console.log(response);
 ## Model routing and aliases
 
 Model routing is configured within the `llm` section of your agentgateway configuration file. 
-The `llm` section offers a simplified, model-centric approach compared to the traditional `binds/listeners/routes` model; for more details on the two approaches, see [LLM configuration modes]({{< link-hextra path="/llm/configuration-modes/" >}}).
+The `llm` section offers a simplified, model-centric approach compared to the `gateways` and `routes` model; for more details on the two approaches, see [LLM configuration modes]({{< link-hextra path="/llm/configuration-modes/" >}}).
 The model configurations shown in this section live under the `llm.models` key.
 
 Agentgateway routes requests by matching an incoming model name, and then sending it to the configured model.

--- a/content/docs/standalone/main/llm/api-types/completions.md
+++ b/content/docs/standalone/main/llm/api-types/completions.md
@@ -25,25 +25,25 @@ llm:
       apiKey: "$OPENAI_API_KEY"
 ```
 
-To configure the route type explicitly, use the `binds/listeners/routes` format and set the `completions` route type in the `policies.ai.routes` map.
+To configure the route type explicitly, use the `gateways` and `routes` format and set the `completions` route type in the `policies.ai.routes` map.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI: {}
-      policies:
-        ai:
-          routes:
-            "/v1/chat/completions": "completions"
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI: {}
+  policies:
+    ai:
+      routes:
+        "/v1/chat/completions": "completions"
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/llm/api-types/embeddings.md
+++ b/content/docs/standalone/main/llm/api-types/embeddings.md
@@ -25,25 +25,25 @@ llm:
       apiKey: "$OPENAI_API_KEY"
 ```
 
-To configure the route type explicitly, use the `binds/listeners/routes` format and set the `embeddings` route type in the `policies.ai.routes` map.
+To configure the route type explicitly, use the `gateways` and `routes` format and set the `embeddings` route type in the `policies.ai.routes` map.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI: {}
-      policies:
-        ai:
-          routes:
-            "/v1/embeddings": "embeddings"
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI: {}
+  policies:
+    ai:
+      routes:
+        "/v1/embeddings": "embeddings"
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/llm/api-types/messages.md
+++ b/content/docs/standalone/main/llm/api-types/messages.md
@@ -30,26 +30,26 @@ llm:
       apiKey: "$ANTHROPIC_API_KEY"
 ```
 
-To configure the route type explicitly, use the `binds/listeners/routes` format and set the `messages` route type in the `policies.ai.routes` map. To also support token counting, map `/v1/messages/count_tokens` to the `anthropicTokenCount` route type.
+To configure the route type explicitly, use the `gateways` and `routes` format and set the `messages` route type in the `policies.ai.routes` map. To also support token counting, map `/v1/messages/count_tokens` to the `anthropicTokenCount` route type.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: anthropic
-          provider:
-            anthropic: {}
-      policies:
-        ai:
-          routes:
-            "/v1/messages": "messages"
-            "/v1/messages/count_tokens": "anthropicTokenCount"
-        backendAuth:
-          key: "$ANTHROPIC_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: anthropic
+      provider:
+        anthropic: {}
+  policies:
+    ai:
+      routes:
+        "/v1/messages": "messages"
+        "/v1/messages/count_tokens": "anthropicTokenCount"
+    backendAuth:
+      key: "$ANTHROPIC_API_KEY"
 ```
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/llm/api-types/passthrough.md
+++ b/content/docs/standalone/main/llm/api-types/passthrough.md
@@ -30,26 +30,26 @@ llm:
     passthrough: opaque
 ```
 
-To configure passthrough as a fallback for unmatched paths in the `binds/listeners/routes` format, map the `*` wildcard path to the `passthrough` route type.
+To configure passthrough as a fallback for unmatched paths in the `gateways` and `routes` format, map the `*` wildcard path to the `passthrough` route type.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI: {}
-      policies:
-        ai:
-          routes:
-            "/v1/chat/completions": "completions"
-            "*": "passthrough"
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI: {}
+  policies:
+    ai:
+      routes:
+        "/v1/chat/completions": "completions"
+        "*": "passthrough"
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 ## Extract telemetry from passthrough traffic

--- a/content/docs/standalone/main/llm/api-types/realtime.md
+++ b/content/docs/standalone/main/llm/api-types/realtime.md
@@ -39,41 +39,41 @@ Set up your agentgateway configuration with the `realtime` route type and a tran
    ```yaml {paths="realtime-standalone"}
    cat <<'EOF' > config.yaml
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   binds:
-   - port: 3000
-     listeners:
-     - routes:
-       - matches:
-         - path:
-             pathPrefix: "/v1/realtime"
-         backends:
-         - ai:
-             name: openai
-             provider:
-               openAI: {}
-         policies:
-           ai:
-             routes:
-               "/v1/realtime": "realtime"
-           backendAuth:
-             key: "$OPENAI_API_KEY"
-           transformations:
-             request:
-               remove:
-               - sec-websocket-extensions
-       - backends:
-         - ai:
-             name: openai
-             provider:
-               openAI:
-                 model: gpt-4
-         policies:
-           ai:
-             routes:
-               "/v1/chat/completions": "completions"
-               "*": "passthrough"
-           backendAuth:
-             key: "$OPENAI_API_KEY"
+   gateways:
+     default:
+       port: 3000
+   routes:
+   - matches:
+     - path:
+         pathPrefix: "/v1/realtime"
+     backends:
+     - ai:
+         name: openai
+         provider:
+           openAI: {}
+     policies:
+       ai:
+         routes:
+           "/v1/realtime": "realtime"
+       backendAuth:
+         key: "$OPENAI_API_KEY"
+       transformations:
+         request:
+           remove:
+           - sec-websocket-extensions
+   - backends:
+     - ai:
+         name: openai
+         provider:
+           openAI:
+             model: gpt-4
+     policies:
+       ai:
+         routes:
+           "/v1/chat/completions": "completions"
+           "*": "passthrough"
+       backendAuth:
+         key: "$OPENAI_API_KEY"
    EOF
    ```
 

--- a/content/docs/standalone/main/llm/api-types/rerank.md
+++ b/content/docs/standalone/main/llm/api-types/rerank.md
@@ -27,25 +27,25 @@ llm:
       apiKey: "$COHERE_API_KEY"
 ```
 
-To configure the route type explicitly, use the `binds/listeners/routes` format and set the `rerank` route type in the `policies.ai.routes` map.
+To configure the route type explicitly, use the `gateways` and `routes` format and set the `rerank` route type in the `policies.ai.routes` map.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: cohere
-          provider:
-            cohere: {}
-      policies:
-        ai:
-          routes:
-            "/v2/rerank": "rerank"
-        backendAuth:
-          key: "$COHERE_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: cohere
+      provider:
+        cohere: {}
+  policies:
+    ai:
+      routes:
+        "/v2/rerank": "rerank"
+    backendAuth:
+      key: "$COHERE_API_KEY"
 ```
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/llm/api-types/responses.md
+++ b/content/docs/standalone/main/llm/api-types/responses.md
@@ -25,25 +25,25 @@ llm:
       apiKey: "$OPENAI_API_KEY"
 ```
 
-To configure the route type explicitly, use the `binds/listeners/routes` format and set the `responses` route type in the `policies.ai.routes` map.
+To configure the route type explicitly, use the `gateways` and `routes` format and set the `responses` route type in the `policies.ai.routes` map.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI: {}
-      policies:
-        ai:
-          routes:
-            "/v1/responses": "responses"
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI: {}
+  policies:
+    ai:
+      routes:
+        "/v1/responses": "responses"
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/llm/api-types/token-count.md
+++ b/content/docs/standalone/main/llm/api-types/token-count.md
@@ -25,26 +25,26 @@ llm:
       apiKey: "$ANTHROPIC_API_KEY"
 ```
 
-To configure the route type explicitly, use the `binds/listeners/routes` format and set the `anthropicTokenCount` route type in the `policies.ai.routes` map. Most configurations also map `/v1/messages` to the `messages` route type for the actual model request.
+To configure the route type explicitly, use the `gateways` and `routes` format and set the `anthropicTokenCount` route type in the `policies.ai.routes` map. Most configurations also map `/v1/messages` to the `messages` route type for the actual model request.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 4000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: anthropic
-          provider:
-            anthropic: {}
-      policies:
-        ai:
-          routes:
-            "/v1/messages": "messages"
-            "/v1/messages/count_tokens": "anthropicTokenCount"
-        backendAuth:
-          key: "$ANTHROPIC_API_KEY"
+gateways:
+  default:
+    port: 4000
+routes:
+- backends:
+  - ai:
+      name: anthropic
+      provider:
+        anthropic: {}
+  policies:
+    ai:
+      routes:
+        "/v1/messages": "messages"
+        "/v1/messages/count_tokens": "anthropicTokenCount"
+    backendAuth:
+      key: "$ANTHROPIC_API_KEY"
 ```
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/llm/configuration-modes.md
+++ b/content/docs/standalone/main/llm/configuration-modes.md
@@ -7,7 +7,9 @@ description: Use traditional HTTP routing configuration for advanced use cases l
 Agentgateway offers two ways to configure LLM providers, each optimized for different use cases.
 
 - [LLM-based configuration](#simplified-llm-configuration)
-- [Routing-based configuration](#traditional-http-routing-configuration)
+- [Routing-based configuration](#routing-based-configuration)
+
+Both modes serve traffic on a [gateway]({{< link-hextra path="/configuration/gateways/" >}}), which defines the port that agentgateway listens on. The difference is how you describe what the gateway serves: the `llm` section describes models, and the `routes` section describes HTTP routes and backends.
 
 ## Choosing between the two
 
@@ -23,7 +25,7 @@ You can use both configuration modes in the same file if needed, but typically o
 | Do you need model-based routing with header matching? | Yes | LLM-based configuration |
 | Do you need custom, path-based routing (e.g., `/openai`, `/anthropic`)? | Yes | Routing-based configuration |
 | Do you need to route to non-LLM backends? | Yes | Routing-based configuration |
-| Do you need multiple listeners on different ports? | Yes | Routing-based configuration |
+| Do you need to serve different content on different ports? | Yes | Routing-based configuration |
 
 ## Simplified LLM configuration
 
@@ -95,38 +97,43 @@ llm:
 
 ### LLM listener ports and TLS
 
-In simplified LLM mode, the local listener uses `llm.port` (default `4000`). MCP uses `mcp.port` (default `3000`).
+To set the port and TLS settings for LLM traffic, define a gateway and attach the `llm` section to it. When you omit the `gateways` field, the `llm` section attaches to the gateway named `default`. The `mcp` and `ui` sections attach the same way, so all three can share one port.
 
-Use `llm.tls` to serve the local LLM listener over TLS. 
+Use the gateway's `tls` field to serve LLM traffic over TLS.
 - Most deployments only need `cert` and `key`.
 - Use `root` for a custom trust bundle or mTLS.
 - Other advanced TLS tuning options include `cipherSuites`, `minTLSVersion`, `maxTLSVersion`, and `keyExchangeGroups`.
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
+gateways:
+  default:
+    port: 8443
+    tls:
+      cert: /etc/agentgateway/tls/tls.crt
+      key: /etc/agentgateway/tls/tls.key
 llm:
-  port: 8443
-  tls:
-    cert: /etc/agentgateway/tls/tls.crt
-    key: /etc/agentgateway/tls/tls.key
   models:
   - name: "*"
     provider: openAI
     params:
       apiKey: "$OPENAI_API_KEY"
-mcp:
-  port: 3000
+mcp: {}
 ```
+
+{{< callout type="info" >}}
+The `llm.port`, `llm.tls`, and `mcp.port` fields are deprecated in favor of gateways. They still work, and when you set them without a gateway, LLM traffic defaults to port `4000` and MCP traffic to port `3000`.
+{{< /callout >}}
 
 For more MCP listener context, see [MCP overview]({{< link-hextra path="/mcp/" >}}).
 
-## Traditional HTTP routing configuration
+## Routing-based configuration
 
-The traditional `binds/listeners/routes` configuration provides full control over HTTP routing. Use this approach when you need advanced HTTP routing capabilities or non-LLM backends.
+The `gateways` and `routes` configuration provides full control over HTTP routing. Use this approach when you need advanced HTTP routing capabilities or non-LLM backends.
 
 ### About
 
-When to use the traditional routing-based configuration:
+When to use the routing-based configuration:
 
 - You need complex HTTP routing based on paths, methods, or query parameters.
 - You are routing to non-LLM backends alongside LLM providers.
@@ -137,27 +144,27 @@ The benefits of this approach are:
 - **Flexible routing**: Full HTTP routing capabilities with path, method, query, and header matching.
 - **Mixed backends**: Route to both LLM and non-LLM backends in the same configuration.
 - **HTTP policies**: Access to all HTTP-level policies like CORS, rate limiting, and transformations.
-- **Multiple listeners**: Configure different ports and protocols.
+- **Multiple gateways**: Configure different ports and protocols, and serve the same route on more than one of them.
 
 ### Example
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 
-binds:
-- port: 3000
-  listeners:
-  - protocol: HTTP
-    routes:
-    - backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-3.5-turbo
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes:
+- backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-3.5-turbo
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
 ```
 
 ### Advanced example with HTTP routing
@@ -165,45 +172,45 @@ binds:
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 
-binds:
-- port: 3000
-  listeners:
-  - protocol: HTTP
-    routes:
-    # Route OpenAI requests
-    - name: openai-route
-      matches:
-      - path:
-          pathPrefix: /openai
-      backends:
-      - ai:
-          name: openai
-          provider:
-            openAI:
-              model: gpt-4o
-      policies:
-        backendAuth:
-          key: "$OPENAI_API_KEY"
-    # Route Anthropic requests
-    - name: anthropic-route
-      matches:
-      - path:
-          pathPrefix: /anthropic
-      backends:
-      - ai:
-          name: anthropic
-          provider:
-            anthropic:
-              model: claude-3-5-haiku-20241022
-      policies:
-        backendAuth:
-          key: "$ANTHROPIC_API_KEY"
-    # Non-LLM backend
-    - name: api-route
-      matches:
-      - path:
-          pathPrefix: /api
-      backends:
-      - http:
-          host: api.example.com:443
+gateways:
+  default:
+    port: 3000
+    protocol: HTTP
+routes:
+# Route OpenAI requests
+- name: openai-route
+  matches:
+  - path:
+      pathPrefix: /openai
+  backends:
+  - ai:
+      name: openai
+      provider:
+        openAI:
+          model: gpt-4o
+  policies:
+    backendAuth:
+      key: "$OPENAI_API_KEY"
+# Route Anthropic requests
+- name: anthropic-route
+  matches:
+  - path:
+      pathPrefix: /anthropic
+  backends:
+  - ai:
+      name: anthropic
+      provider:
+        anthropic:
+          model: claude-3-5-haiku-20241022
+  policies:
+    backendAuth:
+      key: "$ANTHROPIC_API_KEY"
+# Non-LLM backend
+- name: api-route
+  matches:
+  - path:
+      pathPrefix: /api
+  backends:
+  - http:
+      host: api.example.com:443
 ```

--- a/content/docs/standalone/main/llm/configuration-modes.md
+++ b/content/docs/standalone/main/llm/configuration-modes.md
@@ -120,9 +120,8 @@ llm:
 mcp: {}
 ```
 
-{{< callout type="info" >}}
-The `llm.port`, `llm.tls`, and `mcp.port` fields are deprecated in favor of gateways. They still work, and when you set them without a gateway, LLM traffic defaults to port `4000` and MCP traffic to port `3000`.
-{{< /callout >}}
+> [!NOTE]
+> The `llm.port`, `llm.tls`, and `mcp.port` fields are deprecated in favor of gateways. They still work, and when you set them without a gateway, LLM traffic defaults to port `4000` and MCP traffic to port `3000`.
 
 For more MCP listener context, see [MCP overview]({{< link-hextra path="/mcp/" >}}).
 

--- a/content/docs/standalone/main/llm/providers/azure.md
+++ b/content/docs/standalone/main/llm/providers/azure.md
@@ -98,22 +98,22 @@ For advanced Azure AI scenarios, use the traditional listener/route configuratio
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - matches:
-      - path:
-          pathPrefix: /azure
-      backends:
-      - ai:
-          name: azure
-          provider:
-            azure:
-              resourceName: "your-resource-name"
-              projectName: "your-project-name"
-              resourceType: foundry
-              model: gpt-4.1
+gateways:
+  default:
+    port: 3000
+routes:
+- matches:
+  - path:
+      pathPrefix: /azure
+  backends:
+  - ai:
+      name: azure
+      provider:
+        azure:
+          resourceName: "your-resource-name"
+          projectName: "your-project-name"
+          resourceType: foundry
+          model: gpt-4.1
 ```
 
 {{< reuse "agw-docs/snippets/review-configuration.md" >}}
@@ -127,30 +127,30 @@ binds:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - matches:
-      - path:
-          pathPrefix: /azure
-      policies:
-        backendAuth:
-          azure:
-            explicitConfig:
-              clientSecret:
-                tenantId: "<your-tenant-id>"
-                clientId: "<your-client-id>"
-                clientSecret: "<your-client-secret>"
-      backends:
-      - ai:
-          name: azure
-          provider:
-            azure:
-              resourceName: "your-resource-name"
-              projectName: "your-project-name"
-              resourceType: foundry
-              model: gpt-4.1
+gateways:
+  default:
+    port: 3000
+routes:
+- matches:
+  - path:
+      pathPrefix: /azure
+  policies:
+    backendAuth:
+      azure:
+        explicitConfig:
+          clientSecret:
+            tenantId: "<your-tenant-id>"
+            clientId: "<your-client-id>"
+            clientSecret: "<your-client-secret>"
+  backends:
+  - ai:
+      name: azure
+      provider:
+        azure:
+          resourceName: "your-resource-name"
+          projectName: "your-project-name"
+          resourceType: foundry
+          model: gpt-4.1
 ```
 
 {{< reuse "agw-docs/snippets/review-configuration.md" >}}
@@ -163,26 +163,26 @@ binds:
 **Client secret authentication**
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: azure
-          provider:
-            azure:
-              resourceName: "your-resource-name"
-              resourceType: openAI
-              model: gpt-4.1
-      policies:
-        backendAuth:
-          azure:
-            explicitConfig:
-              clientSecret:
-                tenantId: "<your-tenant-id>"
-                clientId: "<your-client-id>"
-                clientSecret: "<your-client-secret>"
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: azure
+      provider:
+        azure:
+          resourceName: "your-resource-name"
+          resourceType: openAI
+          model: gpt-4.1
+  policies:
+    backendAuth:
+      azure:
+        explicitConfig:
+          clientSecret:
+            tenantId: "<your-tenant-id>"
+            clientId: "<your-client-id>"
+            clientSecret: "<your-client-secret>"
 ```
 
 {{< reuse "agw-docs/snippets/review-configuration.md" >}}
@@ -202,23 +202,23 @@ To use system-assigned managed identity:
 Leave the `managedIdentity` field empty so that the system assigns a managed identity to use.
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: azure
-          provider:
-            azure:
-              resourceName: "your-resource-name"
-              resourceType: openAI
-              model: gpt-4.1
-      policies:
-        backendAuth:
-          azure:
-            explicitConfig:
-              managedIdentity: {}
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: azure
+      provider:
+        azure:
+          resourceName: "your-resource-name"
+          resourceType: openAI
+          model: gpt-4.1
+  policies:
+    backendAuth:
+      azure:
+        explicitConfig:
+          managedIdentity: {}
 ```
 
 {{< reuse "agw-docs/snippets/review-configuration.md" >}}
@@ -239,28 +239,28 @@ To use user-assigned managed identity:
 Specify the client ID of the user-assigned managed identity to use. You can also specify the object ID or resource ID instead.
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: azure
-          provider:
-            azure:
-              resourceName: "your-resource-name"
-              resourceType: openAI
-              model: gpt-4.1
-      policies:
-        backendAuth:
-          azure:
-            explicitConfig:
-              managedIdentity:
-                userAssignedIdentity:
-                  clientId: "<your-managed-identity-client-id>"
-                  # OR use objectId or resourceId instead
-                  # objectId: "your-managed-identity-object-id"
-                  # resourceId: "/subscriptions/.../resourceGroups/.../providers/Microsoft.ManagedIdentity/userAssignedIdentities/..."
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: azure
+      provider:
+        azure:
+          resourceName: "your-resource-name"
+          resourceType: openAI
+          model: gpt-4.1
+  policies:
+    backendAuth:
+      azure:
+        explicitConfig:
+          managedIdentity:
+            userAssignedIdentity:
+              clientId: "<your-managed-identity-client-id>"
+              # OR use objectId or resourceId instead
+              # objectId: "your-managed-identity-object-id"
+              # resourceId: "/subscriptions/.../resourceGroups/.../providers/Microsoft.ManagedIdentity/userAssignedIdentities/..."
 ```
 
 {{< reuse "agw-docs/snippets/review-configuration.md" >}}
@@ -279,24 +279,24 @@ To use workload identity:
 
 ```yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - ai:
-          name: azure
-          provider:
-            azure:
-              resourceName: "your-resource-name"
-              resourceType: openAI
-              model: gpt-4.1
-      policies:
-        backendAuth:
-          azure:
-            explicitConfig:
-              workloadIdentity: {}
-        backendTLS: {}
+gateways:
+  default:
+    port: 3000
+routes:
+- backends:
+  - ai:
+      name: azure
+      provider:
+        azure:
+          resourceName: "your-resource-name"
+          resourceType: openAI
+          model: gpt-4.1
+  policies:
+    backendAuth:
+      azure:
+        explicitConfig:
+          workloadIdentity: {}
+    backendTLS: {}
 ```
 
 {{< reuse "agw-docs/snippets/review-configuration.md" >}}

--- a/content/docs/standalone/main/llm/providers/openai.md
+++ b/content/docs/standalone/main/llm/providers/openai.md
@@ -32,7 +32,7 @@ llm:
 | `params.apiKey` | The OpenAI API key for authentication. You can reference environment variables using the `$VAR_NAME` syntax. |
 
 {{< callout type="info" >}}
-For advanced routing scenarios that require path-based routing or custom endpoints, use the traditional `binds/listeners/routes` configuration format. See the [Routing-based configuration guide]({{< link-hextra path="/llm/configuration-modes/" >}}) for more information.
+For advanced routing scenarios that require path-based routing or custom endpoints, use the `gateways` and `routes` configuration format. See the [Routing-based configuration guide]({{< link-hextra path="/llm/configuration-modes/" >}}) for more information.
 {{< /callout >}}
 
 {{< callout type="info" >}}

--- a/content/docs/standalone/main/mcp/about.md
+++ b/content/docs/standalone/main/mcp/about.md
@@ -16,7 +16,7 @@ An MCP server exposes external data sources and tools so that LLM applications c
 
 With agentgateway, you can connect to one or multiple MCP servers in any environment. The agentgateway proxies requests to the MCP tool that is exposed on the server. You can also use the agentgateway to federate tools from multiple MCP servers. For more information, see the [virtual MCP]({{< link-hextra path="/mcp/connect/virtual" >}}) guide. 
 
-In standalone mode, MCP and LLM can run on separate listener ports (`llm.port` defaults to `4000`, `mcp.port` defaults to `3000`) or share one listener when both ports are set to the same value. If `llm.tls` is configured, do not share ports; keep `mcp.port` and `llm.port` separate. For details, see [Routing-based configuration for LLMs]({{< link-hextra path="/llm/configuration-modes/" >}}).
+In standalone mode, MCP and LLM traffic can share one gateway or use separate gateways. Attach the `mcp` and `llm` sections to the same gateway to serve both on one port, or to different gateways to keep them on separate ports. For details, see [Gateways]({{< link-hextra path="/configuration/gateways/" >}}) and [Routing-based configuration for LLMs]({{< link-hextra path="/llm/configuration-modes/" >}}).
 
 ## MCP vs. A2A
 

--- a/content/docs/standalone/main/mcp/connect/virtual.md
+++ b/content/docs/standalone/main/mcp/connect/virtual.md
@@ -78,18 +78,18 @@ routes:
       
       ```yaml
       # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-      binds:
-      - port: 3000
-        listeners:
-        - routes:
-          - policies:
-              cors:
-                allowOrigins: ["*"]
-                allowHeaders: ["*"]
-                exposeHeaders: ["Mcp-Session-Id"]
-            backends:
-            - mcp:
-                targets:
+      gateways:
+        default:
+          port: 3000
+      routes:
+      - policies:
+          cors:
+            allowOrigins: ["*"]
+            allowHeaders: ["*"]
+            exposeHeaders: ["Mcp-Session-Id"]
+        backends:
+        - mcp:
+            targets:
       ...
       ```
 

--- a/content/docs/standalone/main/mcp/guardrails/setup.md
+++ b/content/docs/standalone/main/mcp/guardrails/setup.md
@@ -45,68 +45,68 @@ In this guide, you route `tools/call` and `tools/list` requests through a sample
 2. In another terminal, create a `config.yaml` file. The MCP backend exposes a local stdio MCP server, and the `mcpGuardrails` policy on the route sends selected MCP methods through the ExtMCP server.
    ```yaml
    # yaml-language-server: $schema=https://agentgateway.dev/schema/config
-   binds:
-   - port: 3000
-     listeners:
-     - routes:
-       - policies:
-           cors:
-             allowOrigins:
-             - "*"
-             allowHeaders:
-             - mcp-protocol-version
-             - content-type
-             - mcp-session-id
-             exposeHeaders:
-             - "Mcp-Session-Id"
-           mcpGuardrails:
-             processors:
-             - kind: remote
-               host: "localhost:9001"
-               failureMode: failClosed
-               methods:
-                 tools/call: request
-                 tools/list: response
-         backends:
-         - mcp:
-             targets:
-             - name: everything
-               stdio:
-                 cmd: npx
-                 args: ["@modelcontextprotocol/server-everything"]
+   gateways:
+     default:
+       port: 3000
+   routes:
+   - policies:
+       cors:
+         allowOrigins:
+         - "*"
+         allowHeaders:
+         - mcp-protocol-version
+         - content-type
+         - mcp-session-id
+         exposeHeaders:
+         - "Mcp-Session-Id"
+       mcpGuardrails:
+         processors:
+         - kind: remote
+           host: "localhost:9001"
+           failureMode: failClosed
+           methods:
+             tools/call: request
+             tools/list: response
+     backends:
+     - mcp:
+         targets:
+         - name: everything
+           stdio:
+             cmd: npx
+             args: ["@modelcontextprotocol/server-everything"]
    ```
 
    {{< doc-test paths="mcp-guardrails" >}}
    cat <<'EOF' > config.yaml
-   binds:
-   - port: 3000
-     listeners:
-     - routes:
-       - policies:
-           cors:
-             allowOrigins:
-             - "*"
-             allowHeaders:
-             - mcp-protocol-version
-             - content-type
-             - mcp-session-id
-             exposeHeaders:
-             - "Mcp-Session-Id"
-           mcpGuardrails:
-             processors:
-             - kind: remote
-               host: "localhost:9001"
-               failureMode: failClosed
-               methods:
-                 tools/call: request
-                 tools/list: response
-         backends:
-         - mcp:
-             targets:
-             - name: everything
-               stdio:
-                 cmd: npx
-                 args: ["@modelcontextprotocol/server-everything"]
+   gateways:
+     default:
+       port: 3000
+   routes:
+   - policies:
+       cors:
+         allowOrigins:
+         - "*"
+         allowHeaders:
+         - mcp-protocol-version
+         - content-type
+         - mcp-session-id
+         exposeHeaders:
+         - "Mcp-Session-Id"
+       mcpGuardrails:
+         processors:
+         - kind: remote
+           host: "localhost:9001"
+           failureMode: failClosed
+           methods:
+             tools/call: request
+             tools/list: response
+     backends:
+     - mcp:
+         targets:
+         - name: everything
+           stdio:
+             cmd: npx
+             args: ["@modelcontextprotocol/server-everything"]
    EOF
    {{< /doc-test >}}
 


### PR DESCRIPTION
Closes #793 

- `-13x` files are not new, just the old way preserved for the retired 1.3, 1.2 etc directories
- guides are updated to use gateways instead of binds in most places
- does not update any examples reused from `agentgateway/examples/*/config.yaml` code examples
- new gateways topic in `content/docs/standalone/main/configuration/gateways.md` to explain