### PR TITLE
docs: add backend service load balancing clarification

### DIFF
--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -56,7 +56,7 @@ When you use the `host` and `port` fields (available on all provider types) to p
 
 ```yaml
 apiVersion: agentgateway.dev/v1alpha1
-kind: AgentgatewayBackend
+kind: {{< reuse "agw-docs/snippets/backend.md" >}}
 metadata:
   name: my-backend
   namespace: agentgateway-system

--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -55,7 +55,7 @@ When you register an LLM provider backend that points at an in-cluster Kubernete
 When you use the `host` and `port` fields (available on all provider types) to point at a normal Kubernetes Service with a `ClusterIP`, traffic goes through kube-proxy. Agentgateway sees only a single backend endpoint (the Service's ClusterIP), and kube-proxy handles the load balancing across individual Pods using iptables or IPVS rules. Agentgateway's P2C load balancing and health-aware scoring does **not** apply across individual Pod replicas in this case.
 
 ```yaml
-apiVersion: agentgateway.dev/v1alpha1
+apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
 kind: {{< reuse "agw-docs/snippets/backend.md" >}}
 metadata:
   name: my-backend

--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -131,7 +131,7 @@ For **health-aware P2C load balancing** across individual Pod replicas, use the 
 
    ```yaml
    kubectl apply -f- <<EOF
-   apiVersion: agentgateway.dev/v1alpha1
+   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
    kind: {{< reuse "agw-docs/snippets/backend.md" >}}
    metadata:
      name: my-backend

--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -105,9 +105,8 @@ spec:
 
 For **health-aware P2C load balancing** across individual Pod replicas, use the `custom` provider type with the `backendRef` field. Agentgateway resolves the Service's `EndpointSlices` directly and applies its P2C load balancing and health scoring across individual Pods, bypassing kube-proxy entirely.
 
-{{< callout type="info" >}}
-The `backendRef` field is only available for the `custom` provider type. Use this approach when you want agentgateway's health-aware load balancing across replicas of a self-hosted LLM backend.
-{{< /callout >}}
+> [!NOTE]
+> The `backendRef` field is only available for the `custom` provider type. Use this approach when you want agentgateway's health-aware load balancing across replicas of a self-hosted LLM backend.
 
 1. Create a Service for your LLM backend.
 

--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -88,7 +88,7 @@ spec:
     targetPort: 8000
 ---
 apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
-kind: AgentgatewayBackend
+kind: {{< reuse "agw-docs/snippets/backend.md" >}}
 metadata:
   name: my-backend
   namespace: agentgateway-system

--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -45,6 +45,112 @@ When you configure multiple [priority groups]({{< link-hextra path="/llm/failove
 
 This combines the benefits of automatic intelligent load balancing with explicit priority-based failover control.
 
+
+## Load balancing across Pod replicas
+
+When you register an LLM provider backend that points at an in-cluster Kubernetes Service with multiple Pod replicas behind it, the load balancing behavior depends on how the backend is configured.
+
+### Using `host`/`port` with a normal ClusterIP Service
+
+When you use the `host` and `port` fields (available on all provider types) to point at a normal Kubernetes Service with a `ClusterIP`, traffic goes through kube-proxy. Agentgateway sees only a single backend endpoint (the Service's ClusterIP), and kube-proxy handles the load balancing across individual Pods using iptables or IPVS rules. Agentgateway's P2C load balancing and health-aware scoring does **not** apply across individual Pod replicas in this case.
+
+```yaml
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: my-backend
+  namespace: agentgateway-system
+spec:
+  ai:
+    provider:
+      openai:
+        model: my-model
+      host: my-llm-service.my-namespace.svc.cluster.local  # Normal ClusterIP Service
+      port: 80
+```
+
+### Using `host`/`port` with a headless Service
+
+When you point `host`/`port` at a **headless Service** (`clusterIP: None`) backed by multiple pods, agentgateway re-resolves DNS periodically and can distribute traffic across the resolved Pod IPs. However, this is **not health-aware** — agentgateway does not monitor the health of individual Pod endpoints or evict unhealthy ones in this scenario.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-llm-service
+  namespace: my-namespace
+spec:
+  clusterIP: None  # Headless Service
+  selector:
+    app: my-llm
+  ports:
+  - port: 8000
+    targetPort: 8000
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: my-backend
+  namespace: agentgateway-system
+spec:
+  ai:
+    provider:
+      openai:
+        model: my-model
+      host: my-llm-service.my-namespace.svc.cluster.local  # Headless Service
+      port: 8000
+```
+
+### Using `custom` provider with `backendRef` (Recommended)
+
+For **health-aware P2C load balancing** across individual Pod replicas, use the `custom` provider type with the `backendRef` field. Agentgateway resolves the Service's `EndpointSlices` directly and applies its P2C load balancing and health scoring across individual Pods, bypassing kube-proxy entirely.
+
+{{< callout type="info" >}}
+The `backendRef` field is only available for the `custom` provider type. Use this approach when you want agentgateway's health-aware load balancing across replicas of a self-hosted LLM backend.
+{{< /callout >}}
+
+1. Create a Service for your LLM backend.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: my-llm-service
+     namespace: my-namespace
+   spec:
+     selector:
+       app: my-llm
+     ports:
+     - port: 8000
+       targetPort: 8000
+       protocol: TCP
+   EOF
+   ```
+
+2. Create an {{< reuse "agw-docs/snippets/backend.md" >}} using the `custom` provider type with `backendRef`.
+
+   ```yaml
+   kubectl apply -f- <<EOF
+   apiVersion: agentgateway.dev/v1alpha1
+   kind: {{< reuse "agw-docs/snippets/backend.md" >}}
+   metadata:
+     name: my-backend
+     namespace: {{< reuse "agw-docs/snippets/namespace.md" >}}
+   spec:
+     ai:
+       provider:
+         custom:
+           model: my-model
+         backendRef:
+           name: my-llm-service
+           namespace: my-namespace
+           port: 8000
+   EOF
+   ```
+
+Agentgateway will automatically discover all Pod endpoints behind the Service and apply its P2C load balancing algorithm with health-aware scoring across them.
+
 ## Before you begin
 
 1. Set up an [agentgateway proxy]({{< link-hextra path="/setup/gateway/" >}}).

--- a/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
+++ b/assets/agw-docs/pages/agentgateway/llm/load-balancing.md
@@ -87,7 +87,7 @@ spec:
   - port: 8000
     targetPort: 8000
 ---
-apiVersion: agentgateway.dev/v1alpha1
+apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
 kind: AgentgatewayBackend
 metadata:
   name: my-backend


### PR DESCRIPTION
Clarify how AgentGateway handles load balancing across Pod replicas
behind Kubernetes Services (addresses agentgateway/agentgateway#2714).

Add a new section "Load balancing across Pod replicas" with three
subsections explaining the different scenarios:

- **Using \`host\`/\`port\` with a normal ClusterIP Service**: kube-proxy
  handles load balancing. AgentGateway sees only a single endpoint
  (the Service ClusterIP), P2C does NOT apply across Pod replicas.

- **Using \`host\`/\`port\` with a headless Service**: AgentGateway
  re-resolves DNS periodically, but this is NOT health-aware — no
  endpoint monitoring or eviction.

- **Using \`custom\` provider with \`backendRef\` (Recommended)**:
  AgentGateway resolves EndpointSlices directly and applies P2C
  load balancing with health-aware scoring across individual Pods,
  bypassing kube-proxy entirely. The \`backendRef\` field is only
  available for the \`custom\` provider type.

Includes YAML examples for each scenario.