### PR TITLE
[fix] agentgatewaymodel import

### DIFF
--- a/content/docs/kubernetes/latest/llm/models/about.md
+++ b/content/docs/kubernetes/latest/llm/models/about.md
@@ -8,7 +8,7 @@ test: skip
 Learn how the `{{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}` API provides a model-centric way to serve LLMs in Kubernetes.
 
 > [!WARNING]
-> The `{{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}` API is experimental and disabled by default. The `v1alpha1` API is subject to change in a future release. To enable it, set the `agentgatewayModels.enabled=true` Helm value on the {{< reuse "agw-docs/snippets/agentgateway.md" >}} control plane.
+> The `{{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}` API is experimental and disabled by default. To enable it, set the `agentgatewayModels.enabled=true` Helm value on the {{< reuse "agw-docs/snippets/agentgateway.md" >}} control plane.
 
 ## About
 
@@ -62,7 +62,7 @@ spec:
         from: All
       # Enables the listener's built-in LLM paths
       kinds:
-      - group: {{< reuse "agw-docs/snippets/group.md" >}}
+      - group: agentgateway.dev
         kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 ```
 
@@ -86,7 +86,7 @@ spec:
       namespaces:
         from: All
       kinds:
-      - group: {{< reuse "agw-docs/snippets/group.md" >}}
+      - group: agentgateway.dev
         kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
       - group: gateway.networking.k8s.io
         kind: HTTPRoute
@@ -123,7 +123,7 @@ A model that names its provider is a concrete model. It is an `{{< reuse "agw-do
 The following example shows the pieces that a concrete model configures. Only `parentRefs` and `provider` are required.
 
 ```yaml
-apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+apiVersion: agentgateway.dev/v1alpha1
 kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 metadata:
   name: gpt-5-mini
@@ -184,7 +184,7 @@ A wildcard model usually pairs with a `model` transformation, because the provid
 A model resource is an alias by construction. The name that clients request is `metadata.name` or `match.model`, and the name that the provider receives comes from a `model` transformation. To publish `fast` as an alias for `gpt-3.5-turbo`, create a model named `fast` that rewrites the field.
 
 ```yaml
-apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+apiVersion: agentgateway.dev/v1alpha1
 kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 metadata:
   name: fast
@@ -255,7 +255,7 @@ A model that routes across other models is a virtual model. It is an `{{< reuse 
 The following example splits traffic across two concrete models by weight.
 
 ```yaml
-apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+apiVersion: agentgateway.dev/v1alpha1
 kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 metadata:
   name: balanced

--- a/content/docs/kubernetes/latest/llm/models/serve.md
+++ b/content/docs/kubernetes/latest/llm/models/serve.md
@@ -76,7 +76,7 @@ A listener serves LLM traffic only when it allows the `{{< reuse "agw-docs/snipp
          kinds:
          - group: gateway.networking.k8s.io
            kind: HTTPRoute
-         - group: {{< reuse "agw-docs/snippets/group.md" >}}
+         - group: agentgateway.dev
            kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    EOF
    ```
@@ -142,7 +142,7 @@ When you omit `spec.match`, the model matches `metadata.name` exactly. Clients r
 
    ```yaml {paths="serve-model"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: gpt-4
@@ -265,7 +265,7 @@ Use `spec.match.model` to match more than one model name. The provider does not 
 
    ```yaml {paths="serve-model"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: openai-models
@@ -374,7 +374,7 @@ Real providers require credentials. Use `spec.policies.auth` to read them from a
 
    ```yaml {paths="serve-model"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: gpt-5-mini

--- a/content/docs/kubernetes/latest/llm/models/virtual.md
+++ b/content/docs/kubernetes/latest/llm/models/virtual.md
@@ -69,7 +69,7 @@ Targets are usually `Internal` models, so clients cannot request them directly a
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: internal-fast
@@ -88,7 +88,7 @@ Targets are usually `Internal` models, so clients cannot request them directly a
        - field: model
          expression: '"resolved-internal-fast"'
    ---
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: internal-premium
@@ -153,7 +153,7 @@ Use `virtualModel.weighted` to distribute requests across targets by relative we
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: balanced
@@ -241,7 +241,7 @@ Use `virtualModel.conditional` to select a target with a CEL expression. Targets
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: smart
@@ -373,7 +373,7 @@ Failover depends on eviction. Configure `policies.health` on the concrete target
      - port: 9235
        targetPort: 9235
    ---
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: primary-down
@@ -404,7 +404,7 @@ Failover depends on eviction. Configure `policies.health` on the concrete target
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: resilient

--- a/content/docs/kubernetes/main/llm/models/about.md
+++ b/content/docs/kubernetes/main/llm/models/about.md
@@ -62,7 +62,7 @@ spec:
         from: All
       # Enables the listener's built-in LLM paths
       kinds:
-      - group: {{< reuse "agw-docs/snippets/group.md" >}}
+      - group: agentgateway.dev
         kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 ```
 
@@ -86,7 +86,7 @@ spec:
       namespaces:
         from: All
       kinds:
-      - group: {{< reuse "agw-docs/snippets/group.md" >}}
+      - group: agentgateway.dev
         kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
       - group: gateway.networking.k8s.io
         kind: HTTPRoute
@@ -123,7 +123,7 @@ A model that names its provider is a concrete model. It is an `{{< reuse "agw-do
 The following example shows the pieces that a concrete model configures. Only `parentRefs` and `provider` are required.
 
 ```yaml
-apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+apiVersion: agentgateway.dev/v1alpha1
 kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 metadata:
   name: gpt-5-mini
@@ -184,7 +184,7 @@ A wildcard model usually pairs with a `model` transformation, because the provid
 A model resource is an alias by construction. The name that clients request is `metadata.name` or `match.model`, and the name that the provider receives comes from a `model` transformation. To publish `fast` as an alias for `gpt-3.5-turbo`, create a model named `fast` that rewrites the field.
 
 ```yaml
-apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+apiVersion: agentgateway.dev/v1alpha1
 kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 metadata:
   name: fast
@@ -255,7 +255,7 @@ A model that routes across other models is a virtual model. It is an `{{< reuse 
 The following example splits traffic across two concrete models by weight.
 
 ```yaml
-apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+apiVersion: agentgateway.dev/v1alpha1
 kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
 metadata:
   name: balanced

--- a/content/docs/kubernetes/main/llm/models/serve.md
+++ b/content/docs/kubernetes/main/llm/models/serve.md
@@ -57,7 +57,7 @@ A listener serves LLM traffic only when it allows the `{{< reuse "agw-docs/snipp
          kinds:
          - group: gateway.networking.k8s.io
            kind: HTTPRoute
-         - group: {{< reuse "agw-docs/snippets/group.md" >}}
+         - group: agentgateway.dev
            kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    EOF
    ```
@@ -123,7 +123,7 @@ When you omit `spec.match`, the model matches `metadata.name` exactly. Clients r
 
    ```yaml {paths="serve-model"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: gpt-4
@@ -246,7 +246,7 @@ Use `spec.match.model` to match more than one model name. The provider does not 
 
    ```yaml {paths="serve-model"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: openai-models
@@ -355,7 +355,7 @@ Real providers require credentials. Use `spec.policies.auth` to read them from a
 
    ```yaml {paths="serve-model"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: gpt-5-mini

--- a/content/docs/kubernetes/main/llm/models/virtual.md
+++ b/content/docs/kubernetes/main/llm/models/virtual.md
@@ -69,7 +69,7 @@ Targets are usually `Internal` models, so clients cannot request them directly a
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: internal-fast
@@ -88,7 +88,7 @@ Targets are usually `Internal` models, so clients cannot request them directly a
        - field: model
          expression: '"resolved-internal-fast"'
    ---
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: internal-premium
@@ -153,7 +153,7 @@ Use `virtualModel.weighted` to distribute requests across targets by relative we
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: balanced
@@ -241,7 +241,7 @@ Use `virtualModel.conditional` to select a target with a CEL expression. Targets
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: smart
@@ -373,7 +373,7 @@ Failover depends on eviction. Configure `policies.health` on the concrete target
      - port: 9235
        targetPort: 9235
    ---
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: primary-down
@@ -404,7 +404,7 @@ Failover depends on eviction. Configure `policies.health` on the concrete target
 
    ```yaml {paths="virtual-models"}
    kubectl apply -f- <<EOF
-   apiVersion: {{< reuse "agw-docs/snippets/api-version.md" >}}
+   apiVersion: agentgateway.dev/v1alpha1
    kind: {{< reuse "agw-docs/snippets/agentgatewaymodel.md" >}}
    metadata:
      name: resilient


### PR DESCRIPTION
- hardcode values so downstream import is correct, which uses the OSS CR for now