### PR TITLE
docs: add vSR example references

### DIFF
--- a/assets/agw-docs/pages/integrations/vllm-semantic-router.md
+++ b/assets/agw-docs/pages/integrations/vllm-semantic-router.md
@@ -19,6 +19,8 @@ The request follows these component boundaries:
 
 `PreRouting` is important when the vSR decision changes the model or adds a header that an HTTPRoute uses for matching. It makes the result available before agentgateway evaluates the route.
 
+When semantic caching is enabled, vSR can instead return a cached completion as an immediate ExtProc response. Agentgateway returns the response to the client without calling the configured backend.
+
 ## Choose an integration path
 
 The vSR and agentgateway projects provide complementary guides. Choose the one that matches the models and outcome that you want to evaluate.
@@ -27,7 +29,7 @@ The vSR and agentgateway projects provide complementary guides. Choose the one t
 {{< card link="https://vllm-sr.ai/docs/installation/k8s/agentgateway/" title="Deploy vSR with agentgateway" icon="external-link" description="Follow the vSR project guide to deploy the components on Kubernetes and route to vLLM-compatible inference workloads.">}}
 {{< card link="https://github.com/agentgateway/agentgateway/tree/main/examples/llm-semantic-routing/k8s/cost-based" title="Evaluate cost-based routing" icon="external-link" description="Select between hosted model tiers and measure the result with a model cost catalog and OpenTelemetry.">}}
 {{< card link="https://github.com/agentgateway/agentgateway/tree/main/examples/llm-semantic-routing/k8s/tier-aware" title="Configure tier-aware routing" icon="external-link" description="Select separate vSR configurations and model pools for authenticated Basic, Standard, and Pro callers.">}}
-{{< card link="https://github.com/agentgateway/agentgateway/pull/2883" title="Preview semantic caching" icon="external-link" description="Review the proposed Redis-backed example for reusing responses to semantically equivalent requests.">}}
+{{< card link="https://github.com/agentgateway/agentgateway/tree/main/examples/llm-semantic-routing/k8s/semantic-cache" title="Configure semantic caching" icon="external-link" description="Reuse responses to semantically equivalent requests with the Redis-backed example.">}}
 {{< /cards >}}
 
 The vSR deployment guide owns the installation, Helm values, and semantic-router configuration. Each agentgateway example owns the policies and runnable gateway resources for its scenario. Keeping those details with their projects avoids version drift in this integration overview.

--- a/assets/agw-docs/pages/integrations/vllm-semantic-router.md
+++ b/assets/agw-docs/pages/integrations/vllm-semantic-router.md
@@ -25,10 +25,12 @@ The vSR and agentgateway projects provide complementary guides. Choose the one t
 
 {{< cards >}}
 {{< card link="https://vllm-sr.ai/docs/installation/k8s/agentgateway/" title="Deploy vSR with agentgateway" icon="external-link" description="Follow the vSR project guide to deploy the components on Kubernetes and route to vLLM-compatible inference workloads.">}}
-{{< card link="https://github.com/agentgateway/agentgateway/tree/main/examples/llm-semantic-routing" title="Evaluate cost-based routing" icon="external-link" description="Use the agentgateway example to select between hosted model tiers and measure the result with a model cost catalog and OpenTelemetry.">}}
+{{< card link="https://github.com/agentgateway/agentgateway/tree/main/examples/llm-semantic-routing/k8s/cost-based" title="Evaluate cost-based routing" icon="external-link" description="Select between hosted model tiers and measure the result with a model cost catalog and OpenTelemetry.">}}
+{{< card link="https://github.com/agentgateway/agentgateway/tree/main/examples/llm-semantic-routing/k8s/tier-aware" title="Configure tier-aware routing" icon="external-link" description="Select separate vSR configurations and model pools for authenticated Basic, Standard, and Pro callers.">}}
+{{< card link="https://github.com/agentgateway/agentgateway/pull/2883" title="Preview semantic caching" icon="external-link" description="Review the proposed Redis-backed example for reusing responses to semantically equivalent requests.">}}
 {{< /cards >}}
 
-The vSR deployment guide owns the installation, Helm values, and semantic-router configuration. The agentgateway example owns the cost-routing policy and runnable gateway resources. Keeping those details with their projects avoids version drift in this integration overview.
+The vSR deployment guide owns the installation, Helm values, and semantic-router configuration. Each agentgateway example owns the policies and runnable gateway resources for its scenario. Keeping those details with their projects avoids version drift in this integration overview.
 
 > [!NOTE]
 > Current vSR examples require agentgateway 1.3.0 or later for the external-processing options that control request streaming and mode overrides.


### PR DESCRIPTION
<!--
Thanks for adding your company to the agentgateway homepage!

Requirements are documented here:
https://github.com/agentgateway/website/blob/main/CONTRIBUTING.md#adding-your-organizations-logo
-->

## Company

**Name (as it should appear under the logo):** Not applicable

**Website:** Not applicable

## Contribution summary

Update the vLLM Semantic Router integration page to:

- point the cost-based example to its current directory;
- add the tier-aware routing example; and
- reference the proposed semantic-cache example in https://github.com/agentgateway/agentgateway/pull/2883.

Validated with a production Hugo build for the `main` and `latest` pages.

## Checklist

**Logo file:** Not applicable; documentation-only change.

**Listing:** Not applicable; documentation-only change.

## Preview

Not applicable; the production Hugo build completed successfully.
