### PR TITLE
docs: fix mcp.tool.arguments availability in MCP authorization

### DIFF
--- a/content/docs/standalone/latest/configuration/security/mcp-authz.md
+++ b/content/docs/standalone/latest/configuration/security/mcp-authz.md
@@ -83,7 +83,7 @@ routes:
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That unauthorized tools are actually filtered — would require an
 #     authenticated tools/list call with a JWT carrying the right claims.
-#   * The tool-arguments fragment later on the page is not a standalone config.
+#   * The access-log fragment later on the page is not a standalone config.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 gateways:
@@ -167,7 +167,7 @@ The following MCP-specific CEL variables are available in authorization rules:
 |----------|------|-------------|-------------|
 | `mcp.tool.name` | `string` | Request-time | The name of the tool being called. |
 | `mcp.tool.target` | `string` | Request-time | The target backend handling the tool call. |
-| `mcp.tool.arguments` | `map` | Request-time | The JSON arguments passed to the tool call. |
+| `mcp.tool.arguments` | `map` | Post-request | The JSON arguments passed to the tool call (access logs only). |
 | `mcp.tool.result` | `any` | Post-request | The tool call result payload (access logs only). |
 | `mcp.tool.error` | `any` | Post-request | The tool call error payload (access logs only). |
 | `mcp.prompt.name` | `string` | Request-time | The name of the prompt being accessed. |
@@ -177,14 +177,17 @@ The following MCP-specific CEL variables are available in authorization rules:
 
 Request-time variables are available during authorization and can be used in `mcpAuthorization` rules. Post-request variables are available in access log CEL expressions.
 
-### Authorize based on tool arguments
+### Tool arguments are not available during authorization
 
-You can use tool arguments in authorization rules to enforce fine-grained access control. For example, restrict which URLs a fetch tool can access:
+`mcp.tool.arguments` is populated only after a tool call completes, so it cannot be referenced in `mcpAuthorization` rules. Base authorization decisions on `mcp.tool.name` and `mcp.tool.target` instead.
+
+To inspect tool arguments, use an access log policy, which evaluates post-request:
 
 ```yaml
-mcpAuthorization:
-  rules:
-  - 'mcp.tool.name == "fetch" && mcp.tool.arguments.url.startsWith("https://internal.")'
+frontendPolicies:
+  accessLog:
+    add:
+      tool_args: 'mcp.tool.arguments'
 ```
 
-Refer to the [CEL reference]({{< link-hextra path="/reference/cel/" >}}) for additional variables.
+See [MCP observability]({{< link-hextra path="/mcp/mcp-observability" >}}) for the full example, and the [CEL reference]({{< link-hextra path="/reference/cel/" >}}) for additional variables.

--- a/content/docs/standalone/latest/mcp/mcp-observability.md
+++ b/content/docs/standalone/latest/mcp/mcp-observability.md
@@ -93,11 +93,11 @@ The following CEL variables are available in access log policies but are **not**
 
 | Variable | Availability | Description |
 |----------|-------------|-------------|
-| `mcp.methodName` | Request-time | The MCP JSON-RPC method name, such as `tools/call` or `tools/list`. |
-| `mcp.sessionId` | Request-time | The MCP session ID. |
+| `mcp.methodName` | Post-request | The MCP JSON-RPC method name, such as `tools/call` or `tools/list`. |
+| `mcp.sessionId` | Post-request | The MCP session ID. |
 | `mcp.tool.name` | Request-time | The name of the tool being called. |
 | `mcp.tool.target` | Request-time | The target backend handling the tool call. |
-| `mcp.tool.arguments` | Request-time | The JSON arguments passed to the tool call. |
+| `mcp.tool.arguments` | Post-request | The JSON arguments passed to the tool call. |
 | `mcp.tool.result` | Post-request | The tool call result payload. |
 | `mcp.tool.error` | Post-request | The tool call error payload. |
 

--- a/content/docs/standalone/main/configuration/security/mcp-authz.md
+++ b/content/docs/standalone/main/configuration/security/mcp-authz.md
@@ -83,7 +83,7 @@ routes:
 # WHAT THIS TEST DOES NOT VALIDATE (and why):
 #   * That unauthorized tools are actually filtered — would require an
 #     authenticated tools/list call with a JWT carrying the right claims.
-#   * The tool-arguments fragment later on the page is not a standalone config.
+#   * The access-log fragment later on the page is not a standalone config.
 cat <<'EOF' > config.yaml
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 gateways:
@@ -167,7 +167,7 @@ The following MCP-specific CEL variables are available in authorization rules:
 |----------|------|-------------|-------------|
 | `mcp.tool.name` | `string` | Request-time | The name of the tool being called. |
 | `mcp.tool.target` | `string` | Request-time | The target backend handling the tool call. |
-| `mcp.tool.arguments` | `map` | Request-time | The JSON arguments passed to the tool call. |
+| `mcp.tool.arguments` | `map` | Post-request | The JSON arguments passed to the tool call (access logs only). |
 | `mcp.tool.result` | `any` | Post-request | The tool call result payload (access logs only). |
 | `mcp.tool.error` | `any` | Post-request | The tool call error payload (access logs only). |
 | `mcp.prompt.name` | `string` | Request-time | The name of the prompt being accessed. |
@@ -177,14 +177,17 @@ The following MCP-specific CEL variables are available in authorization rules:
 
 Request-time variables are available during authorization and can be used in `mcpAuthorization` rules. Post-request variables are available in access log CEL expressions.
 
-### Authorize based on tool arguments
+### Tool arguments are not available during authorization
 
-You can use tool arguments in authorization rules to enforce fine-grained access control. For example, restrict which URLs a fetch tool can access:
+`mcp.tool.arguments` is populated only after a tool call completes, so it cannot be referenced in `mcpAuthorization` rules. Base authorization decisions on `mcp.tool.name` and `mcp.tool.target` instead.
+
+To inspect tool arguments, use an access log policy, which evaluates post-request:
 
 ```yaml
-mcpAuthorization:
-  rules:
-  - 'mcp.tool.name == "fetch" && mcp.tool.arguments.url.startsWith("https://internal.")'
+frontendPolicies:
+  accessLog:
+    add:
+      tool_args: 'mcp.tool.arguments'
 ```
 
-Refer to the [CEL reference]({{< link-hextra path="/reference/cel/" >}}) for additional variables.
+See [MCP observability]({{< link-hextra path="/mcp/mcp-observability" >}}) for the full example, and the [CEL reference]({{< link-hextra path="/reference/cel/" >}}) for additional variables.

--- a/content/docs/standalone/main/mcp/mcp-observability.md
+++ b/content/docs/standalone/main/mcp/mcp-observability.md
@@ -93,11 +93,11 @@ The following CEL variables are available in access log policies but are **not**
 
 | Variable | Availability | Description |
 |----------|-------------|-------------|
-| `mcp.methodName` | Request-time | The MCP JSON-RPC method name, such as `tools/call` or `tools/list`. |
-| `mcp.sessionId` | Request-time | The MCP session ID. |
+| `mcp.methodName` | Post-request | The MCP JSON-RPC method name, such as `tools/call` or `tools/list`. |
+| `mcp.sessionId` | Post-request | The MCP session ID. |
 | `mcp.tool.name` | Request-time | The name of the tool being called. |
 | `mcp.tool.target` | Request-time | The target backend handling the tool call. |
-| `mcp.tool.arguments` | Request-time | The JSON arguments passed to the tool call. |
+| `mcp.tool.arguments` | Post-request | The JSON arguments passed to the tool call. |
 | `mcp.tool.result` | Post-request | The tool call result payload. |
 | `mcp.tool.error` | Post-request | The tool call error payload. |
 


### PR DESCRIPTION
## Summary

Fixes #523. The docs claimed `mcp.tool.arguments` is available at request-time for `mcpAuthorization` rules. It isn't — request-time CEL for MCP only exposes identity fields (`tool.name`, `tool.target`, etc.); arguments are populated post-request for logging/tracing only.

Verified against `agentgateway/agentgateway`:
- `test_rbac_mcp_context_is_identity_only` (`crates/agentgateway/src/http/authorization_tests.rs`) asserts `!has(mcp.tool.arguments)` during RBAC evaluation.
- `MCPInfo`'s doc comment in `crates/agentgateway/src/cel/types.rs` states request-time CEL is identity-only; post-request CEL adds `methodName`, `sessionId`, and tool payloads.

## Changes

- `configuration/security/mcp-authz.md` (main + latest): moved `mcp.tool.arguments` to "Post-request" in the CEL variables table, and replaced the "Authorize based on tool arguments" section — which showed an example that can't work — with a note plus a working access-log example.
- `mcp/mcp-observability.md` (main + latest): the same table there also mislabeled `mcp.tool.arguments`, `mcp.methodName`, and `mcp.sessionId` as request-time; corrected all three to post-request.

## Test plan

- [x] Vale passes on both changed pages
- [x] `python3 scripts/doc_test_run.py --file content/docs/standalone/main/configuration/security/mcp-authz.md --product standalone --generate-only` — generated script unaffected by the edits (unchanged tagged blocks)
- [x] Full `hugo` build succeeds