### PR TITLE
docs: add `permissive` mode and mark `optional` as default for `apiKey.mode` in virtual-keys

### DIFF
--- a/assets/agw-docs/standalone/virtual-keys.md
+++ b/assets/agw-docs/standalone/virtual-keys.md
@@ -108,7 +108,7 @@ EOF
 
 | Setting | Description |
 | -- | -- |
-| `apiKey.mode` | Set to `strict` to require a valid API key for all requests. Use `optional` to allow unauthenticated requests. |
+| `apiKey.mode` | The API key authentication mode. `strict` requires a valid API key for all requests. `optional` (default) validates the key if one is present but allows unauthenticated requests. `permissive` never rejects requests, which is useful when later steps such as authorization or logging rely on API key claims. |
 | `apiKey.keys` | List of API keys. Each key has a `key` value and optional `metadata`. |
 | `key` | The API key value that users include in the `Authorization: Bearer <key>` header. |
 | `metadata` | Optional metadata associated with the key, such as a user identifier or tier. |


### PR DESCRIPTION
The "Virtual key management" page documents `apiKey.mode` with only two values (`strict` and `optional`), but the "API Key authentication" reference page documents three: `strict`, `optional` (default), and `permissive`. See:
- https://agentgateway.dev/docs/standalone/latest/llm/cost-controls/virtual-keys.md
- https://agentgateway.dev/docs/standalone/latest/configuration/security/apikey-authn.md

This aligns `virtual-keys.md` with the authoritative `apikey-authn.md` page:
- adds the missing `permissive` mode
- marks `optional` as the default

Docs-only change. The edited table lives in the shared asset `assets/agw-docs/standalone/virtual-keys.md`, reused by both the `latest` and `main` standalone pages, so a single edit fixes both.