### PR TITLE
github-table timeout extension

### DIFF
--- a/content/docs/standalone/latest/configuration/static-configuration.md
+++ b/content/docs/standalone/latest/configuration/static-configuration.md
@@ -15,4 +15,5 @@ The following table shows the `config` file schema for static configurations at 
 {{% github-table url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/schema/config.md" 
    section="Configuration File Schema"
    exclude="^\\|.(gateways|routes|tcpRoutes|ui|binds|frontendPolicies|policies|services|workloads|backends|llm|mcp|routeGroups)"
+   timeout="120s"
 %}}

--- a/content/docs/standalone/main/configuration/static-configuration.md
+++ b/content/docs/standalone/main/configuration/static-configuration.md
@@ -15,4 +15,5 @@ The following table shows the `config` file schema for static configurations at 
 {{% github-table url="https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/schema/config.md" 
    section="Configuration File Schema"
    exclude="^\\|.(gateways|routes|tcpRoutes|ui|binds|frontendPolicies|policies|services|workloads|backends|llm|mcp|routeGroups)"
+   timeout="120s"
 %}}


### PR DESCRIPTION
The whole table has to be retrieved, even just to get a subset of the content. And it's too long and timing out sometimes.