### PR TITLE
PullPolicy link fix

### DIFF
--- a/.github/workflows/reference-docs.yaml
+++ b/.github/workflows/reference-docs.yaml
@@ -225,7 +225,19 @@ jobs:
           # underlying types (e.g. `map[string]CELExpression` -> #map[string]celexpression,
           # which never gets a heading), keeping the readable type text.
           sed -i.bak -E 's/_Underlying type:_ _\[(map\[[^]]*\][^]]*)\]\(#[^)]*\)_/_Underlying type:_ _\1_/g' "$TARGET_FILE"
+          # Repoint the PullPolicy link. crd-ref-docs templates a kubernetes.io URL for
+          # every k8s.io type, but PullPolicy is a type alias with no section of its own,
+          # so #pullpolicy-v1-core does not exist and the link lands a reader nowhere.
+          # knownTypes cannot override it (see scripts/crd-ref-docs-config.yaml).
+          sed -i.bak -E 's|https://kubernetes\.io/docs/reference/generated/kubernetes-api/v?[0-9.]+/#pullpolicy-v1-core|https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy|g' "$TARGET_FILE"
           rm -f "$TARGET_FILE.bak"
+
+          # A sed that silently stops matching would quietly reintroduce the broken
+          # anchor, so fail the run instead of opening a PR that carries it.
+          if grep -q '#pullpolicy-v1-core' "$TARGET_FILE"; then
+            echo "Error: PullPolicy anchor rewrite did not match in $TARGET_FILE"
+            exit 1
+          fi
 
           rm "./out.md"
           echo "API docs generated successfully at $TARGET_FILE"

--- a/scripts/crd-ref-docs-config.yaml
+++ b/scripts/crd-ref-docs-config.yaml
@@ -60,5 +60,12 @@ render:
     # knownTypes entry for them is silently ignored. Entries for PullPolicy and
     # metav1.Duration used to live here and never took effect. When a generated
     # kubernetes.io anchor is broken (for example #pullpolicy-v1-core, which is a
-    # type alias with no section of its own), rewrite it in the post-processing
-    # step of .github/workflows/reference-docs.yaml instead.
+    # type alias with no section of its own), add a sed to the post-processing
+    # block in the "Generate API docs" step of .github/workflows/reference-docs.yaml
+    # instead. Do not patch the generated api-*.md files by hand: the next regen
+    # reverts the edit, and the regen runs nightly.
+    #
+    # Reserve those rewrites for links that are genuinely wrong for a reader.
+    # Links that merely redirect (git.k8s.io, for one) belong in the exclude list
+    # in docs-link-checking/lychee.toml, not here: rewriting them pins a URL that
+    # can rot, which is worse than the redirect.


### PR DESCRIPTION
Fixes a broken anchor in the generated API reference.

`crd-ref-docs` templates a `kubernetes.io` URL for every k8s type, so the `pullPolicy` field links to `#pullpolicy-v1-core`. That anchor doesn't exist — `PullPolicy` is a type alias with no section of its own — so the link drops readers at the top of a very long API page. Repointed to the concepts page, which is where the field is actually documented.

The rewrite is one `sed` added to the post-processing block that already runs in **Generate agentgateway API docs**, plus a guard that fails the run if the pattern stops matching, so a silently-stale regex can't quietly reintroduce the bad anchor.

## Why here and not elsewhere

- **Not in `knownTypes`.** `LinkForType` checks `IsKubeType` before `IsKnownType`, so any entry for a k8s type is silently ignored. An entry for `PullPolicy` used to live in the config and never took effect.
- **Not by editing `api-*.md`.** The reference docs regenerate nightly, so a hand-edit is reverted within a day.
- **Not a lychee exclusion.** The anchor is genuinely dead, not a checker artifact. Excluding it would hide a real defect rather than remove noise.

## Upstream

[elastic/crd-ref-docs#143](https://github.com/elastic/crd-ref-docs/pull/143) flips that ordering so `knownTypes` wins, which would make this workaround unnecessary. It's been open since March 2025 and needs a rebase. If it merges, we pick it up automatically (the workflow runs `@latest`) and can drop the `sed` in favor of a `knownTypes` entry.
