### PR TITLE
Added PDF export (and a couple link fixes)

### DIFF
--- a/content/docs/kubernetes/latest/_index.md
+++ b/content/docs/kubernetes/latest/_index.md
@@ -3,6 +3,21 @@ title: Version 1.5.x
 weight: 460
 description: Use agentgateway in a Kubernetes environment. 
 test: skip
+# PDF export. This one page opting into `book` is the whole opt-in: the format
+# stitches this page plus its entire .Pages subtree into one print document, so
+# the PDF is scoped to this version tree by where the opt-in lives. The
+# standalone tree opts in separately and publishes its own manual; the frozen
+# version directories deliberately do not, so only /latest/ offers a download.
+#
+# LIST THE WHOLE SET, not just html and book. Hugo's `outputs` REPLACES a page's
+# defaults rather than adding to them, so `["html", "book"]` would silently drop
+# this page's .md, RSS and llms.txt. Nothing fails and only this page is
+# affected, which is exactly why it would survive review. These four are
+# `outputs.section` from hugo.yaml, copied, plus `book`.
+#
+# The book is not built by an ordinary build: docs-theme-extras gates it behind
+# `HUGO_PARAMS_BUILDBOOK=true`, which only the PDF workflow in solo-io/docs sets.
+outputs: ["html", "rss", "markdown", "llms", "book"]
 ---
 
 Welcome to the documentation for using agentgateway on Kubernetes!

--- a/content/docs/kubernetes/latest/observability/access-logs/_index.md
+++ b/content/docs/kubernetes/latest/observability/access-logs/_index.md
@@ -2,4 +2,13 @@
 title: Access logs
 weight: 10
 description: Capture, filter, enrich, and export per-request access logs.
+# This page was `security/access-logging` before it moved under observability.
+# The shared agw-docs pages still link the old path, correctly — the enterprise
+# hub kept that name (content/en/agentgateway/kubernetes/latest/security/
+# access-logging.md), and those files are unioned into BOTH builds, so the link
+# cannot simply be repointed without breaking the hub. A version-scoped alias
+# resolves it on this side and leaves the shared source alone. Scoped, not bare:
+# an unscoped alias builds at the site root and every version tree fights over it.
+aliases:
+  - /docs/kubernetes/latest/security/access-logging/
 ---

--- a/content/docs/kubernetes/latest/observability/traces/_index.md
+++ b/content/docs/kubernetes/latest/observability/traces/_index.md
@@ -2,6 +2,14 @@
 title: Traces
 weight: 10
 description: Integrate with OpenTelemetry to collect and analyze request traces.
-aliases: 
-  - /observability/tracing
+# An alias is a WHOLE URL path on this site, not a path relative to the version
+# tree it sits in. This used to read `/observability/tracing`, which built a
+# redirect page at the site root instead of inside this tree — so the shared
+# agw-docs pages that link `/observability/tracing/` (still the correct name in
+# the enterprise hub, which did not rename the page) 404'd here. Worse, the
+# `main` tree carried the same unscoped alias, so both trees claimed one site-root
+# URL and whichever built last won: the redirect pointed at `main` regardless of
+# which version you came from.
+aliases:
+  - /docs/kubernetes/latest/observability/tracing/
 ---

--- a/content/docs/kubernetes/main/observability/_index.md
+++ b/content/docs/kubernetes/main/observability/_index.md
@@ -6,8 +6,10 @@ description: Review access logs, metrics, and traces for your agentgateway deplo
 next: /operations
 prev: /integrations
 test: skip
-aliases: 
-  - /observability/tracing
+# Scoped to this version tree. Unscoped, it built at the site root and collided
+# with the identical alias in `latest` — see that tree's traces/_index.md.
+aliases:
+  - /docs/kubernetes/main/observability/tracing/
 ---
 
 > [!NOTE]

--- a/content/docs/standalone/latest/_index.md
+++ b/content/docs/standalone/latest/_index.md
@@ -3,6 +3,11 @@ linkTitle: "Version 1.5.x"
 title: Version 1.5.x
 description: Use agentgateway as a standalone binary.
 test: skip
+# PDF export. See content/docs/kubernetes/latest/_index.md for why the opt-in is
+# one page and why the whole output set is listed rather than just html + book.
+# The two sections are separate trees and publish separate manuals, so each
+# carries its own opt-in.
+outputs: ["html", "rss", "markdown", "llms", "book"]
 ---
 
 Welcome to the documentation for using the standalone binary of the agentgateway open source project! 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/agentgateway/website
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.3.5 // indirect
+require github.com/solo-io/docs-theme-extras v0.3.8-beta.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/agentgateway/website
 
 go 1.21
 
-require github.com/solo-io/docs-theme-extras v0.3.8-beta.1 // indirect
+require github.com/solo-io/docs-theme-extras v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/solo-io/docs-theme-extras v0.3.5 h1:KaCM1CaqV3IyyIY/7uc0z5WHutL0aHA4brV1zGwfGw0=
 github.com/solo-io/docs-theme-extras v0.3.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.3.8-beta.1 h1:RkGWjFml3wjqweICUyh++g1w5WQRkTY5PDZyhXvkLBs=
+github.com/solo-io/docs-theme-extras v0.3.8-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/solo-io/docs-theme-extras v0.3.5 h1:KaCM1CaqV3IyyIY/7uc0z5WHutL0aHA4brV1zGwfGw0=
-github.com/solo-io/docs-theme-extras v0.3.5/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
-github.com/solo-io/docs-theme-extras v0.3.8-beta.1 h1:RkGWjFml3wjqweICUyh++g1w5WQRkTY5PDZyhXvkLBs=
-github.com/solo-io/docs-theme-extras v0.3.8-beta.1/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=
+github.com/solo-io/docs-theme-extras v0.3.8 h1:adccTdWRD21FHUhxv49RKW3VbP+y7d+jXzZMxADAWoM=
+github.com/solo-io/docs-theme-extras v0.3.8/go.mod h1:jjjYu/QoD+vMu30zgcpfEuTEGuJOJWs5qai/K18kltg=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -106,6 +106,31 @@ params:
     # preview URL. Set explicitly here because agw-oss's prod baseURL doesn't
     # include the host.
     prodHost: "https://agentgateway.dev"
+
+  # "Download all docs (PDF)" in the Copy-as-Markdown menu on docs pages, added by
+  # the module's copy-markdown.html. Setting `distribution` turns the item on and
+  # selects the solo-io/docs-pdfs release-asset URL shape, which the module
+  # supplies so it is not repeated per consumer:
+  #
+  #   .../releases/download/{product}-{distribution}-{version}/{product}-{distribution}-{version}.pdf
+  #
+  # `{version}` resolves to `kubernetes-latest` or `standalone-latest`, NOT to
+  # `latest`. This site registers `params.sections`, so the theme prefixes the
+  # version segment with the section — without that, both deployment modes ship a
+  # `latest` line and would resolve to one URL, and the workflow uploads with
+  # --clobber, so whichever rendered last would silently sit behind the link on
+  # both. Only /latest/ opts into `book`, so the frozen version trees and /main/
+  # show no item at all.
+  #
+  # `product` is set explicitly because it is otherwise read from
+  # `params.currentProduct` or `params.folder`, and this site sets neither.
+  #
+  # The item is derived from the build, not hand-written: it renders only where
+  # the tree it belongs to carries the `book` output format.
+  pdfDownload:
+    distribution: oss
+    product: agentgateway
+
   navbar:
     displayTitle: false
     displayLogo: true


### PR DESCRIPTION
Exporting full documentation PDFs to https://github.com/solo-io/docs-pdfs/releases.