### PR TITLE
Revise redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -75,8 +75,8 @@
 /docs/kubernetes/latest/tutorials/prompt-enrichment/ /docs/kubernetes/latest/documentation/llm/prompt-templates 301
 /docs/kubernetes/latest/tutorials/telemetry /docs/kubernetes/latest/documentation/observability/tracing 301
 /docs/kubernetes/latest/tutorials/telemetry/ /docs/kubernetes/latest/documentation/observability/tracing 301
-# Removed top-level Tutorials landing page
-/tutorials /docs 301
+# Removed top-level Tutorials landing page — the content became integration guides
+/tutorials /docs/standalone/latest/integrations/ 301
 
 # LLM spending page renamed to costs
 /docs/standalone/main/llm/spending /docs/standalone/main/documentation/llm/cost-controls/costs 301
@@ -107,8 +107,10 @@
 # Renamed section: /docs/local -> /docs/standalone
 /docs/local/* /docs/standalone/:splat 301
 
-# Removed top-level Tutorials landing page
-/tutorials/* /docs 301
+# Removed top-level Tutorials landing page — the content became integration guides.
+# Subpages flatten to the section landing: the old tutorial slugs do not map
+# one-to-one onto the new integration slugs, so there is nothing to :splat.
+/tutorials/* /docs/standalone/latest/integrations/ 301
 
 # ----------------------------------------------------------------------------
 # Doc tabs: where the old versioned URLs go

--- a/static/_redirects
+++ b/static/_redirects
@@ -171,6 +171,10 @@
 /docs/:section/:version/llm/inference/multiple-inference-pools* /docs/:section/:version/documentation/llm/multiple-inference-pools:splat 301
 # A parent's `url:` does not move its children, so inference-routing and any
 # other child keeps the plain documentation/ prefix; only the landing moved.
+# Hugo emits the landing's old URL with a trailing slash, which the `/*` rule
+# would match with an empty splat and send to documentation/llm/inference/ —
+# a path that renders nothing. Catch the trailing-slash form first.
+/docs/:section/:version/llm/inference/ /docs/:section/:version/documentation/inference/ 301
 /docs/:section/:version/llm/inference/* /docs/:section/:version/documentation/llm/inference/:splat 301
 /docs/:section/:version/llm/inference* /docs/:section/:version/documentation/inference:splat 301
 
@@ -210,7 +214,7 @@
 /docs/:section/:version/integrations/mcp-servers/sse* /docs/:section/:version/integrations/mcp/servers:splat 301
 /docs/:section/:version/integrations/mcp-servers* /docs/:section/:version/integrations/mcp/servers:splat 301
 /docs/:section/:version/integrations/vllm-semantic-router* /docs/:section/:version/integrations/llm/routing/vllm-semantic-router:splat 301
-/docs/:section/:version/integrations/vllm* /docs/:section/:version/integrations/llm/routing/vllm:splat 301
+/docs/:section/:version/integrations/vllm* /docs/:section/:version/integrations/llm/providers/vllm:splat 301
 /docs/:section/:version/integrations/kserve* /docs/:section/:version/integrations/llm/routing/kserve:splat 301
 /docs/:section/:version/integrations/argo* /docs/:section/:version/integrations/ci-cd/argo:splat 301
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -21,21 +21,8 @@
 # Model catalog
 /model-catalog https://raw.githubusercontent.com/agentgateway/agentgateway/main/catalog/model-catalog.json
 
-# Local docs redirects (legacy /docs/* -> versioned /docs/standalone/latest/*)
-# Renamed /docs/local -> /docs/standalone
+# Renamed section: /docs/local -> /docs/standalone
 /docs/local /docs/standalone 301
-
-# Quickstart
-/docs/quickstart /docs/standalone/latest/documentation/quickstart 301
-
-# About
-/docs/about /docs/standalone/latest/documentation/about 301
-
-# Deployment
-/docs/deployment /docs/standalone/latest/deployment 301
-
-# Configuration
-/docs/configuration /docs/standalone/latest/documentation/configuration 301
 
 # Tutorials (removed in solo-io/docs#1872 — content consolidated into other sections)
 # Standalone latest
@@ -88,37 +75,12 @@
 /docs/kubernetes/latest/tutorials/prompt-enrichment/ /docs/kubernetes/latest/documentation/llm/prompt-templates 301
 /docs/kubernetes/latest/tutorials/telemetry /docs/kubernetes/latest/documentation/observability/tracing 301
 /docs/kubernetes/latest/tutorials/telemetry/ /docs/kubernetes/latest/documentation/observability/tracing 301
-# Legacy unversioned tutorial paths
-/docs/tutorials /docs/standalone/latest/documentation/quickstart 301
 # Removed top-level Tutorials landing page
 /tutorials /docs 301
 
-# LLM consumption
-/docs/llm /docs/standalone/latest/documentation/llm 301
+# LLM spending page renamed to costs
 /docs/standalone/main/llm/spending /docs/standalone/main/documentation/llm/cost-controls/costs 301
 /docs/standalone/latest/llm/spending /docs/standalone/latest/documentation/llm/cost-controls/costs 301
-
-# Inference routing
-/docs/inference /docs/standalone/latest/documentation/inference 301
-
-# MCP connectivity (unversioned /docs/mcp → standalone latest).
-# This does NOT match /docs/standalone/.../mcp/... — that is the :section/:version
-# block below. It only catches the old unversioned shortcut. The trailing-slash
-# form is covered by /docs/mcp/* with an empty splat.
-/docs/mcp /docs/standalone/latest/documentation/mcp 301
-
-# Agent connectivity
-/docs/agent /docs/standalone/latest/documentation/agent 301
-
-# Integrations
-/docs/integrations /docs/standalone/latest/integrations 301
-
-# Reference
-/docs/reference /docs/standalone/latest/reference 301
-
-# FAQs
-/docs/faqs /docs/standalone/latest/documentation/faqs 301
-/docs/faqs/ /docs/standalone/latest/documentation/faqs 301
 
 # Cost controls section reorg (issue solo-io/docs#2921)
 /docs/kubernetes/main/llm/costs /docs/kubernetes/main/documentation/llm/cost-controls/costs 301
@@ -142,20 +104,11 @@
 # Redirect all paths under /examples to GitHub raw content
 /examples/* https://raw.githubusercontent.com/agentgateway/agentgateway/main/examples/:splat
 
-# Legacy unversioned /docs/<subject>/* shortcuts
+# Renamed section: /docs/local -> /docs/standalone
 /docs/local/* /docs/standalone/:splat 301
-/docs/quickstart/* /docs/standalone/latest/documentation/quickstart/:splat 301
-/docs/about/* /docs/standalone/latest/documentation/about/:splat 301
-/docs/deployment/* /docs/standalone/latest/deployment/:splat 301
-/docs/configuration/* /docs/standalone/latest/documentation/configuration/:splat 301
-/docs/tutorials/* /docs/standalone/latest/documentation/quickstart 301
+
+# Removed top-level Tutorials landing page
 /tutorials/* /docs 301
-/docs/llm/* /docs/standalone/latest/documentation/llm/:splat 301
-/docs/inference/* /docs/standalone/latest/documentation/inference/:splat 301
-/docs/mcp/* /docs/standalone/latest/documentation/mcp/:splat 301
-/docs/agent/* /docs/standalone/latest/documentation/agent/:splat 301
-/docs/integrations/* /docs/standalone/latest/integrations/:splat 301
-/docs/reference/* /docs/standalone/latest/reference/:splat 301
 
 # ----------------------------------------------------------------------------
 # Doc tabs: where the old versioned URLs go

--- a/static/_redirects
+++ b/static/_redirects
@@ -24,57 +24,6 @@
 # Renamed section: /docs/local -> /docs/standalone
 /docs/local /docs/standalone 301
 
-# Tutorials (removed in solo-io/docs#1872 — content consolidated into other sections)
-# Standalone latest
-/docs/standalone/latest/tutorials /docs/standalone/latest/documentation/quickstart 301
-/docs/standalone/latest/tutorials/ /docs/standalone/latest/documentation/quickstart 301
-/docs/standalone/latest/tutorials/a2a /docs/standalone/latest/documentation/agent/a2a 301
-/docs/standalone/latest/tutorials/a2a/ /docs/standalone/latest/documentation/agent/a2a 301
-/docs/standalone/latest/tutorials/ai-prompt-guard /docs/standalone/latest/documentation/llm/prompt-guards/ 301
-/docs/standalone/latest/tutorials/ai-prompt-guard/ /docs/standalone/latest/documentation/llm/prompt-guards/ 301
-/docs/standalone/latest/tutorials/authorization /docs/standalone/latest/documentation/configuration/security/mcp-authz 301
-/docs/standalone/latest/tutorials/authorization/ /docs/standalone/latest/documentation/configuration/security/mcp-authz 301
-/docs/standalone/latest/tutorials/basic /docs/standalone/latest/documentation/quickstart/mcp 301
-/docs/standalone/latest/tutorials/basic/ /docs/standalone/latest/documentation/quickstart/mcp 301
-/docs/standalone/latest/tutorials/http-routing /docs/standalone/latest/documentation/configuration/routes 301
-/docs/standalone/latest/tutorials/http-routing/ /docs/standalone/latest/documentation/configuration/routes 301
-/docs/standalone/latest/tutorials/llm-gateway /docs/standalone/latest/documentation/llm 301
-/docs/standalone/latest/tutorials/llm-gateway/ /docs/standalone/latest/documentation/llm 301
-/docs/standalone/latest/tutorials/mcp-authentication /docs/standalone/latest/documentation/configuration/security/mcp-authn 301
-/docs/standalone/latest/tutorials/mcp-authentication/ /docs/standalone/latest/documentation/configuration/security/mcp-authn 301
-/docs/standalone/latest/tutorials/mcp-federation /docs/standalone/latest/documentation/mcp/connect/virtual 301
-/docs/standalone/latest/tutorials/mcp-federation/ /docs/standalone/latest/documentation/mcp/connect/virtual 301
-/docs/standalone/latest/tutorials/multiplex /docs/standalone/latest/documentation/mcp/connect/virtual 301
-/docs/standalone/latest/tutorials/multiplex/ /docs/standalone/latest/documentation/mcp/connect/virtual 301
-/docs/standalone/latest/tutorials/oauth2-proxy /docs/standalone/latest/integrations/auth/oauth2-proxy 301
-/docs/standalone/latest/tutorials/oauth2-proxy/ /docs/standalone/latest/integrations/auth/oauth2-proxy 301
-/docs/standalone/latest/tutorials/openapi /docs/standalone/latest/documentation/mcp/connect/openapi 301
-/docs/standalone/latest/tutorials/openapi/ /docs/standalone/latest/documentation/mcp/connect/openapi 301
-/docs/standalone/latest/tutorials/tailscale-auth /docs/standalone/latest/integrations/auth/tailscale 301
-/docs/standalone/latest/tutorials/tailscale-auth/ /docs/standalone/latest/integrations/auth/tailscale 301
-/docs/standalone/latest/tutorials/telemetry /docs/standalone/latest/documentation/observability/traces/configs/otel 301
-/docs/standalone/latest/tutorials/telemetry/ /docs/standalone/latest/documentation/observability/traces/configs/otel 301
-/docs/standalone/latest/tutorials/tls /docs/standalone/latest/documentation/configuration/listeners 301
-/docs/standalone/latest/tutorials/tls/ /docs/standalone/latest/documentation/configuration/listeners 301
-# Kubernetes latest
-/docs/kubernetes/latest/tutorials /docs/kubernetes/latest/documentation/quickstart 301
-/docs/kubernetes/latest/tutorials/ /docs/kubernetes/latest/documentation/quickstart 301
-/docs/kubernetes/latest/tutorials/azure-ai-foundry /docs/kubernetes/latest/documentation/llm/providers/azure 301
-/docs/kubernetes/latest/tutorials/azure-ai-foundry/ /docs/kubernetes/latest/documentation/llm/providers/azure 301
-/docs/kubernetes/latest/tutorials/basic /docs/kubernetes/latest/documentation/quickstart/mcp 301
-/docs/kubernetes/latest/tutorials/basic/ /docs/kubernetes/latest/documentation/quickstart/mcp 301
-/docs/kubernetes/latest/tutorials/claude-code-proxy /docs/kubernetes/latest/integrations/llm-clients/claude-code 301
-/docs/kubernetes/latest/tutorials/claude-code-proxy/ /docs/kubernetes/latest/integrations/llm-clients/claude-code 301
-/docs/kubernetes/latest/tutorials/jwt-authorization /docs/kubernetes/latest/documentation/security/jwt/setup 301
-/docs/kubernetes/latest/tutorials/jwt-authorization/ /docs/kubernetes/latest/documentation/security/jwt/setup 301
-/docs/kubernetes/latest/tutorials/llm-gateway /docs/kubernetes/latest/documentation/quickstart/llm 301
-/docs/kubernetes/latest/tutorials/llm-gateway/ /docs/kubernetes/latest/documentation/quickstart/llm 301
-/docs/kubernetes/latest/tutorials/mcp-federation /docs/kubernetes/latest/documentation/mcp/virtual 301
-/docs/kubernetes/latest/tutorials/mcp-federation/ /docs/kubernetes/latest/documentation/mcp/virtual 301
-/docs/kubernetes/latest/tutorials/prompt-enrichment /docs/kubernetes/latest/documentation/llm/prompt-templates 301
-/docs/kubernetes/latest/tutorials/prompt-enrichment/ /docs/kubernetes/latest/documentation/llm/prompt-templates 301
-/docs/kubernetes/latest/tutorials/telemetry /docs/kubernetes/latest/documentation/observability/tracing 301
-/docs/kubernetes/latest/tutorials/telemetry/ /docs/kubernetes/latest/documentation/observability/tracing 301
 # Removed top-level Tutorials landing page — the content became integration guides
 /tutorials /docs/standalone/latest/integrations/ 301
 
@@ -153,7 +102,6 @@
 /docs/:section/:version/security* /docs/:section/:version/documentation/security:splat 301
 /docs/:section/:version/setup* /docs/:section/:version/documentation/setup:splat 301
 /docs/:section/:version/traffic-management* /docs/:section/:version/documentation/traffic-management:splat 301
-/docs/:section/:version/tutorials* /docs/:section/:version/documentation/tutorials:splat 301
 /docs/:section/:version/inference* /docs/:section/:version/documentation/inference:splat 301
 /docs/:section/:version/faqs* /docs/:section/:version/documentation/faqs:splat 301
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,16 @@
 # Cloudflare Pages Redirects for agentgateway.dev
 # This allows simplified URLs like agentgateway.dev/examples/basic/config.yaml
 # instead of the full GitHub raw URL
+#
+# Cloudflare allows 2,000 static and 100 DYNAMIC redirects. Classification is
+# ORDER-DEPENDENT: the parser treats every rule AFTER the first splat (`*`) or
+# placeholder (`:name`) as dynamic, even exact-path rules, and silently drops
+# anything past the 100th. Keep ALL exact-path rules above this comment's
+# "DYNAMIC" section. See cloudflare/workers-sdk#14694.
+
+# ============================================================================
+# STATIC RULES — exact paths only, no * and no :placeholder
+# ============================================================================
 
 # Installation script shortcut
 /install https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/tools/get-agentgateway
@@ -11,34 +21,21 @@
 # Model catalog
 /model-catalog https://raw.githubusercontent.com/agentgateway/agentgateway/main/catalog/model-catalog.json
 
-# Redirect all paths under /examples to GitHub raw content
-/examples/* https://raw.githubusercontent.com/agentgateway/agentgateway/main/examples/:splat
-
 # Local docs redirects (legacy /docs/* -> versioned /docs/standalone/latest/*)
 # Renamed /docs/local -> /docs/standalone
 /docs/local /docs/standalone 301
-/docs/local/ /docs/standalone 301
-/docs/local/* /docs/standalone/:splat 301
 
 # Quickstart
 /docs/quickstart /docs/standalone/latest/documentation/quickstart 301
-/docs/quickstart/ /docs/standalone/latest/documentation/quickstart 301
-/docs/quickstart/* /docs/standalone/latest/documentation/quickstart/:splat 301
 
 # About
 /docs/about /docs/standalone/latest/documentation/about 301
-/docs/about/ /docs/standalone/latest/documentation/about 301
-/docs/about/* /docs/standalone/latest/documentation/about/:splat 301
 
 # Deployment
 /docs/deployment /docs/standalone/latest/deployment 301
-/docs/deployment/ /docs/standalone/latest/deployment 301
-/docs/deployment/* /docs/standalone/latest/deployment/:splat 301
 
 # Configuration
 /docs/configuration /docs/standalone/latest/documentation/configuration 301
-/docs/configuration/ /docs/standalone/latest/documentation/configuration 301
-/docs/configuration/* /docs/standalone/latest/documentation/configuration/:splat 301
 
 # Tutorials (removed in solo-io/docs#1872 — content consolidated into other sections)
 # Standalone latest
@@ -93,49 +90,35 @@
 /docs/kubernetes/latest/tutorials/telemetry/ /docs/kubernetes/latest/documentation/observability/tracing 301
 # Legacy unversioned tutorial paths
 /docs/tutorials /docs/standalone/latest/documentation/quickstart 301
-/docs/tutorials/ /docs/standalone/latest/documentation/quickstart 301
-/docs/tutorials/* /docs/standalone/latest/documentation/quickstart 301
 # Removed top-level Tutorials landing page
 /tutorials /docs 301
-/tutorials/ /docs 301
-/tutorials/* /docs 301
 
 # LLM consumption
 /docs/llm /docs/standalone/latest/documentation/llm 301
-/docs/llm/ /docs/standalone/latest/documentation/llm 301
-/docs/llm/* /docs/standalone/latest/documentation/llm/:splat 301
 /docs/standalone/main/llm/spending /docs/standalone/main/documentation/llm/cost-controls/costs 301
 /docs/standalone/latest/llm/spending /docs/standalone/latest/documentation/llm/cost-controls/costs 301
 
 # Inference routing
 /docs/inference /docs/standalone/latest/documentation/inference 301
-/docs/inference/ /docs/standalone/latest/documentation/inference 301
-/docs/inference/* /docs/standalone/latest/documentation/inference/:splat 301
 
-# MCP connectivity
+# MCP connectivity (unversioned /docs/mcp → standalone latest).
+# This does NOT match /docs/standalone/.../mcp/... — that is the :section/:version
+# block below. It only catches the old unversioned shortcut. The trailing-slash
+# form is covered by /docs/mcp/* with an empty splat.
 /docs/mcp /docs/standalone/latest/documentation/mcp 301
-/docs/mcp/ /docs/standalone/latest/documentation/mcp 301
-/docs/mcp/* /docs/standalone/latest/documentation/mcp/:splat 301
 
 # Agent connectivity
 /docs/agent /docs/standalone/latest/documentation/agent 301
-/docs/agent/ /docs/standalone/latest/documentation/agent 301
-/docs/agent/* /docs/standalone/latest/documentation/agent/:splat 301
 
 # Integrations
 /docs/integrations /docs/standalone/latest/integrations 301
-/docs/integrations/ /docs/standalone/latest/integrations 301
-/docs/integrations/* /docs/standalone/latest/integrations/:splat 301
 
 # Reference
 /docs/reference /docs/standalone/latest/reference 301
-/docs/reference/ /docs/standalone/latest/reference 301
-/docs/reference/* /docs/standalone/latest/reference/:splat 301
 
 # FAQs
 /docs/faqs /docs/standalone/latest/documentation/faqs 301
 /docs/faqs/ /docs/standalone/latest/documentation/faqs 301
-
 
 # Cost controls section reorg (issue solo-io/docs#2921)
 /docs/kubernetes/main/llm/costs /docs/kubernetes/main/documentation/llm/cost-controls/costs 301
@@ -152,17 +135,36 @@
 /docs/standalone/latest/llm/virtual-keys /docs/standalone/latest/documentation/llm/cost-controls/virtual-keys 301
 
 # ============================================================================
-# Doc tabs: where the old URLs go
-#
-# Cloudflare allows 2,000 static and 100 DYNAMIC redirects per file, and every
-# rule below is dynamic because it carries placeholders. Writing these per
-# version came to 278 rules, so they are collapsed: :section and :version each
-# match one segment, covering kubernetes and standalone across every published
-# version, and a trailing `*` covers the bare path, the trailing-slash form and
-# everything beneath it at once.
-#
+# DYNAMIC RULES — splats and placeholders. Max 100, counted from this point.
 # ORDER IS LOAD-BEARING — Cloudflare applies the first rule that matches.
 # ============================================================================
+
+# Redirect all paths under /examples to GitHub raw content
+/examples/* https://raw.githubusercontent.com/agentgateway/agentgateway/main/examples/:splat
+
+# Legacy unversioned /docs/<subject>/* shortcuts
+/docs/local/* /docs/standalone/:splat 301
+/docs/quickstart/* /docs/standalone/latest/documentation/quickstart/:splat 301
+/docs/about/* /docs/standalone/latest/documentation/about/:splat 301
+/docs/deployment/* /docs/standalone/latest/deployment/:splat 301
+/docs/configuration/* /docs/standalone/latest/documentation/configuration/:splat 301
+/docs/tutorials/* /docs/standalone/latest/documentation/quickstart 301
+/tutorials/* /docs 301
+/docs/llm/* /docs/standalone/latest/documentation/llm/:splat 301
+/docs/inference/* /docs/standalone/latest/documentation/inference/:splat 301
+/docs/mcp/* /docs/standalone/latest/documentation/mcp/:splat 301
+/docs/agent/* /docs/standalone/latest/documentation/agent/:splat 301
+/docs/integrations/* /docs/standalone/latest/integrations/:splat 301
+/docs/reference/* /docs/standalone/latest/reference/:splat 301
+
+# ----------------------------------------------------------------------------
+# Doc tabs: where the old versioned URLs go
+#
+# Writing these per version came to 278 rules, so they are collapsed: :section
+# and :version each match one segment, covering kubernetes and standalone
+# across every published version, and a trailing `*` covers the bare path, the
+# trailing-slash form and everything beneath it at once.
+# ----------------------------------------------------------------------------
 
 # Two inference pages set an explicit `url:`, so they do not live where
 # their file path implies. Most specific first.
@@ -215,4 +217,3 @@
 # Release notes and version support moved out of the Reference tab.
 /docs/:section/:version/reference/release-notes* /docs/:section/:version/release-notes/release-notes:splat 301
 /docs/:section/:version/reference/versions* /docs/:section/:version/release-notes/versions:splat 301
-


### PR DESCRIPTION
Cloudflare has a 100 budget on dynamic redirs, and it counts redirs starting at the first dynamic (even if subsequent are static), xref docs https://developers.cloudflare.com/pages/configuration/redirects/#per-file

- reorg to put static redirs first
- drop some static redirs that are covered by dynamic
- rm pre-sectioned kube/standalone redirs
- rm tutorials, just have dynamic to the new integrations section
- 19/2000 static
- 41/100 dynamic

followup to doc tab reorg in #1004 