### PR TITLE
docs: share backend policy fields across versions

### DIFF
--- a/assets/agw-docs/pages/agentgateway/about/backend-policy-fields.md
+++ b/assets/agw-docs/pages/agentgateway/about/backend-policy-fields.md
@@ -1,0 +1,18 @@
+### Backend policy fields
+
+A `traffic` policy processes a request as it passes through a Gateway listener or route. A `backend` policy applies to the destination that agentgateway selects for that request, and each field configures one aspect of the connection to it.
+
+Combine fields in one policy when they share a target and a lifecycle. For the resources that each field can attach to, and for how two policies that set the same field merge, see [Targeting and merging]({{< link-hextra path="/documentation/about/policies/target-merge/" >}}).
+
+| Field | Purpose | Guide |
+| -- | -- | -- |
+| `backend.tcp` | Set the connection timeout and TCP keepalive probes. | [Backend timeouts]({{< link-hextra path="/documentation/resiliency/timeouts/backend/" >}}) and [HTTP connection settings]({{< link-hextra path="/documentation/resiliency/connection/#backend" >}}) |
+| `backend.http` | Select the upstream HTTP version and set the backend response deadline. | [Backend timeouts]({{< link-hextra path="/documentation/resiliency/timeouts/backend/" >}}) and [HTTP connection settings]({{< link-hextra path="/documentation/resiliency/connection/#backend" >}}) |
+| `backend.tls` | Originate TLS or mutual TLS (mTLS) and configure certificate validation. | [Backend TLS]({{< link-hextra path="/documentation/security/backendtls/" >}}) |
+| `backend.tunnel` | Reach the destination through an HTTP CONNECT proxy. | [Policy API reference]({{< link-hextra path="/reference/api/" >}}) |
+| `backend.auth` | Add credentials or exchange, sign, or pass through tokens for the destination. | [Backend authentication]({{< link-hextra path="/documentation/security/backend-authn/" >}}) |
+| `backend.extAuth` | Run external authorization after agentgateway selects the destination. | [Bring your own external authorization service]({{< link-hextra path="/documentation/security/extauth/byo-ext-auth-service/" >}}) |
+| `backend.transformation` | Transform requests sent to the destination and responses returned from it. | [Transformations]({{< link-hextra path="/documentation/traffic-management/transformations/" >}}) |
+| `backend.health` | Detect unhealthy endpoints, evict them, and restore them after recovery. | [Backend health]({{< link-hextra path="/documentation/resiliency/backend-health/" >}}) |
+| `backend.ai` | Configure prompt guards, routing, transformations, and other AI-specific behavior. | [LLM features]({{< link-hextra path="/documentation/llm/" >}}) |
+| `backend.mcp` | Configure Model Context Protocol (MCP) authorization, authentication, and guardrails. | [MCP features]({{< link-hextra path="/documentation/mcp/" >}}) |

--- a/content/docs/kubernetes/latest/documentation/about/policies/overview.md
+++ b/content/docs/kubernetes/latest/documentation/about/policies/overview.md
@@ -17,24 +17,7 @@ Each {{< reuse "agw-docs/snippets/policy.md" >}} has three top-level sections in
 | `traffic` | Controls how agentgateway processes traffic. Applies at the listener, route, or route rule level. Fields are listed in execution order. | `cors`, `jwtAuthentication`, `basicAuthentication`, `apiKeyAuthentication`, `extAuth`, `authorization`, `rateLimit`, `extProc`, `transformation`, `csrf`, `headerModifiers`, `hostRewrite`, `directResponse`, `buffer`, `timeouts`, `retry` |
 | `backend` | Controls how agentgateway connects to destination backends. Applies at the backend, service, route, or gateway level. | `tcp`, `tls`, `http`, `tunnel`, `transformation`, `auth`, `extAuth`, `health`, `ai`, `mcp` |
 
-### Backend policy fields
-
-A `traffic` policy processes a request as it passes through a Gateway listener or route. A `backend` policy applies to the destination that agentgateway selects for that request, and each field configures one aspect of the connection to it.
-
-Combine fields in one policy when they share a target and a lifecycle. For the resources that each field can attach to, and for how two policies that set the same field merge, see [Targeting and merging]({{< link-hextra path="/documentation/about/policies/target-merge/" >}}).
-
-| Field | Purpose | Guide |
-| -- | -- | -- |
-| `backend.tcp` | Set the connection timeout and TCP keepalive probes. | [Backend timeouts]({{< link-hextra path="/documentation/resiliency/timeouts/backend/" >}}) and [HTTP connection settings]({{< link-hextra path="/documentation/resiliency/connection/#backend" >}}) |
-| `backend.http` | Select the upstream HTTP version and set the backend response deadline. | [Backend timeouts]({{< link-hextra path="/documentation/resiliency/timeouts/backend/" >}}) and [HTTP connection settings]({{< link-hextra path="/documentation/resiliency/connection/#backend" >}}) |
-| `backend.tls` | Originate TLS or mutual TLS (mTLS) and configure certificate validation. | [Backend TLS]({{< link-hextra path="/documentation/security/backendtls/" >}}) |
-| `backend.tunnel` | Reach the destination through an HTTP CONNECT proxy. | [Policy API reference]({{< link-hextra path="/reference/api/" >}}) |
-| `backend.auth` | Add credentials or exchange, sign, or pass through tokens for the destination. | [Backend authentication]({{< link-hextra path="/documentation/security/backend-authn/" >}}) |
-| `backend.extAuth` | Run external authorization after agentgateway selects the destination. | [Bring your own external authorization service]({{< link-hextra path="/documentation/security/extauth/byo-ext-auth-service/" >}}) |
-| `backend.transformation` | Transform requests sent to the destination and responses returned from it. | [Transformations]({{< link-hextra path="/documentation/traffic-management/transformations/" >}}) |
-| `backend.health` | Detect unhealthy endpoints, evict them, and restore them after recovery. | [Backend health]({{< link-hextra path="/documentation/resiliency/backend-health/" >}}) |
-| `backend.ai` | Configure prompt guards, routing, transformations, and other AI-specific behavior. | [LLM features]({{< link-hextra path="/documentation/llm/" >}}) |
-| `backend.mcp` | Configure Model Context Protocol (MCP) authorization, authentication, and guardrails. | [MCP features]({{< link-hextra path="/documentation/mcp/" >}}) |
+{{< reuse "agw-docs/pages/agentgateway/about/backend-policy-fields.md" >}}
 
 ## Example guides
 

--- a/content/docs/kubernetes/latest/documentation/install/advanced.md
+++ b/content/docs/kubernetes/latest/documentation/install/advanced.md
@@ -3,6 +3,8 @@ title: Advanced settings
 weight: 70
 description: Install agentgateway and related components.
 test: skip
+aliases:
+  - /docs/kubernetes/latest/install/advanced/
 ---
 
 {{< reuse "agw-docs/pages/install/advanced.md" >}}

--- a/content/docs/kubernetes/latest/documentation/llm/inference/_index.md
+++ b/content/docs/kubernetes/latest/documentation/llm/inference/_index.md
@@ -4,6 +4,7 @@ weight: 20
 description: Route to your own self-hosted generative AI models with inference workloads.
 url: /docs/kubernetes/latest/documentation/inference/
 aliases:
+  - /docs/kubernetes/latest/inference/
   - /docs/kubernetes/latest/llm/inference/
   - /docs/kubernetes/latest/documentation/llm/inference/
 ---

--- a/content/docs/kubernetes/main/documentation/about/policies/overview.md
+++ b/content/docs/kubernetes/main/documentation/about/policies/overview.md
@@ -17,24 +17,7 @@ Each {{< reuse "agw-docs/snippets/policy.md" >}} has three top-level sections in
 | `traffic` | Controls how agentgateway processes traffic. Applies at the listener, route, or route rule level. Fields are listed in execution order. | `cors`, `jwtAuthentication`, `basicAuthentication`, `apiKeyAuthentication`, `extAuth`, `authorization`, `rateLimit`, `extProc`, `transformation`, `csrf`, `headerModifiers`, `hostRewrite`, `directResponse`, `buffer`, `timeouts`, `retry` |
 | `backend` | Controls how agentgateway connects to destination backends. Applies at the backend, service, route, or gateway level. | `tcp`, `tls`, `http`, `tunnel`, `transformation`, `auth`, `extAuth`, `health`, `ai`, `mcp` |
 
-### Backend policy fields
-
-A `traffic` policy processes a request as it passes through a Gateway listener or route. A `backend` policy applies to the destination that agentgateway selects for that request, and each field configures one aspect of the connection to it.
-
-Combine fields in one policy when they share a target and a lifecycle. For the resources that each field can attach to, and for how two policies that set the same field merge, see [Targeting and merging]({{< link-hextra path="/documentation/about/policies/target-merge/" >}}).
-
-| Field | Purpose | Guide |
-| -- | -- | -- |
-| `backend.tcp` | Set the connection timeout and TCP keepalive probes. | [Backend timeouts]({{< link-hextra path="/documentation/resiliency/timeouts/backend/" >}}) and [HTTP connection settings]({{< link-hextra path="/documentation/resiliency/connection/#backend" >}}) |
-| `backend.http` | Select the upstream HTTP version and set the backend response deadline. | [Backend timeouts]({{< link-hextra path="/documentation/resiliency/timeouts/backend/" >}}) and [HTTP connection settings]({{< link-hextra path="/documentation/resiliency/connection/#backend" >}}) |
-| `backend.tls` | Originate TLS or mutual TLS (mTLS) and configure certificate validation. | [Backend TLS]({{< link-hextra path="/documentation/security/backendtls/" >}}) |
-| `backend.tunnel` | Reach the destination through an HTTP CONNECT proxy. | [Policy API reference]({{< link-hextra path="/reference/api/" >}}) |
-| `backend.auth` | Add credentials or exchange, sign, or pass through tokens for the destination. | [Backend authentication]({{< link-hextra path="/documentation/security/backend-authn/" >}}) |
-| `backend.extAuth` | Run external authorization after agentgateway selects the destination. | [Bring your own external authorization service]({{< link-hextra path="/documentation/security/extauth/byo-ext-auth-service/" >}}) |
-| `backend.transformation` | Transform requests sent to the destination and responses returned from it. | [Transformations]({{< link-hextra path="/documentation/traffic-management/transformations/" >}}) |
-| `backend.health` | Detect unhealthy endpoints, evict them, and restore them after recovery. | [Backend health]({{< link-hextra path="/documentation/resiliency/backend-health/" >}}) |
-| `backend.ai` | Configure prompt guards, routing, transformations, and other AI-specific behavior. | [LLM features]({{< link-hextra path="/documentation/llm/" >}}) |
-| `backend.mcp` | Configure Model Context Protocol (MCP) authorization, authentication, and guardrails. | [MCP features]({{< link-hextra path="/documentation/mcp/" >}}) |
+{{< reuse "agw-docs/pages/agentgateway/about/backend-policy-fields.md" >}}
 
 ## Example guides
 


### PR DESCRIPTION
## Company

**Name (as it should appear under the logo):** N/A — documentation refactor.

**Website:** N/A.

## Contribution summary

- Extract the identical Backend policy fields sections into a shared Markdown file and include it from the main and latest policy overviews. Future edits apply to both versions, preventing drift.
- Restore redirects for the old advanced-installation and inference URLs used by the generated Helm reference, fixing the link-check failure.

## Checklist

Logo file and listing: N/A.

- [x] Preserve the existing section text and links.
- [x] Production Hugo build.
- [x] Compare rendered sections and version-specific links against the original pages.

- [x] Local Lychee report using the CI configuration: zero errors and warnings (redirect destinations and namespace anchor also verified).

## Preview

No intended visual changes.

